### PR TITLE
DS-2969: Fix handling of data series in Scatterplot with all missing values 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipStandardCharts
 Type: Package
 Title: Standard R interactive charts
-Version: 1.13.2
+Version: 1.13.3
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other charting packages. The goal is to provide a

--- a/R/labeledscatterchart.R
+++ b/R/labeledscatterchart.R
@@ -308,13 +308,18 @@ LabeledScatter <- function(x = NULL,
         if (length(groups) != n)
             groups <- rep(" ", n)
 
+        # Get list of all series names - including if those with all NAs
+        groups.ord <- order(suppressWarnings(AsNumeric(groups, binary = FALSE)))
+        g.list.all <- unique(groups[groups.ord])
+        colors <- paste0(rep("", length(g.list.all)), colors)
+        names(colors) <- g.list.all
+
+        # Extract only non-NA points and order based on series name
         groups.ord <- order(suppressWarnings(AsNumeric(groups[not.na], binary = FALSE)))
         not.na <- not.na[groups.ord]
-
         groups <- as.character(groups)
         g.list <- unique(groups[not.na])
-        colors <- paste0(rep("", length(g.list)), colors)
-        names(colors) <- g.list
+        colors <- colors[g.list]
     }
     colors <- StripAlphaChannel(colors)
     if (is.na(data.label.font.autocolor))


### PR DESCRIPTION
The changes in this branch is causing diffs in labeledscatter and scatterplot charts in https://github.com/Displayr/flipChartTests2/tree/master/tests/testthat/snapshots/diff - but these changes are actually correct because certain colors in the supplied palette should be skipped when they are not used.

There are currently no tests added to flipStandardCharts, but these tests that are diffing in flipChartTests2 would test the code in this branch after merging