### PR TITLE
RS-7135: convert all standard charts to iframeless

### DIFF
--- a/R/barchart.R
+++ b/R/barchart.R
@@ -435,7 +435,7 @@ Bar <- function(x,
         bargap = bar.gap,
         barmode = barmode
     )
-    #attr(p, "can-run-in-root-dom") <- TRUE
+    attr(p, "can-run-in-root-dom") <- TRUE
     result <- list(htmlwidget = p)
     class(result) <- "StandardChart"
     attr(result, "ChartType") <- if (is.stacked) "Bar Stacked" else "Bar Clustered"

--- a/R/barmulticolor.R
+++ b/R/barmulticolor.R
@@ -262,7 +262,7 @@ BarMultiColor <- function(x,
         bargap = bar.gap,
         barmode = 'overlay'
     )
-    #attr(p, "can-run-in-root-dom") <- TRUE
+    attr(p, "can-run-in-root-dom") <- TRUE
     result <- list(htmlwidget = p)
     class(result) <- "StandardChart"
     attr(result, "ChartType") <- "Bar Clustered"

--- a/R/columnchart.R
+++ b/R/columnchart.R
@@ -920,7 +920,7 @@ Column <- function(x,
         bargap = bar.gap,
         barmode = barmode
     )
-    #attr(p, "can-run-in-root-dom") <- TRUE
+    attr(p, "can-run-in-root-dom") <- TRUE
     result <- list(htmlwidget = p)
     class(result) <- "StandardChart"
     attr(result, "ChartType") <- if (is.stacked) "Column Stacked" else "Column Clustered"

--- a/R/columnmulticolor.R
+++ b/R/columnmulticolor.R
@@ -248,7 +248,7 @@ ColumnMultiColor <- function(x,
         bargap = bar.gap,
         barmode = 'overlay'
     )
-    #attr(p, "can-run-in-root-dom") <- TRUE
+    attr(p, "can-run-in-root-dom") <- TRUE
     result <- list(htmlwidget = p)
     class(result) <- "StandardChart"
     attr(result, "ChartType") <- "Column Clustered"

--- a/R/deprecated_standardchart.R
+++ b/R/deprecated_standardchart.R
@@ -2674,7 +2674,7 @@ Chart <-   function(y = NULL,
         barmode = barmode
     )
 
-    #attr(p, "can-run-in-root-dom") <- TRUE
+    attr(p, "can-run-in-root-dom") <- TRUE
     result <- list(htmlwidget = p)
     class(result) <- "StandardChart"
     result

--- a/R/distribution.R
+++ b/R/distribution.R
@@ -435,7 +435,7 @@ Distribution <-   function(x,
         paper_bgcolor = toRGB(background.fill.color, alpha = background.fill.opacity))")
     eval(parse(text = txt))
 
-    #attr(p, "can-run-in-root-dom") <- TRUE
+    attr(p, "can-run-in-root-dom") <- TRUE
     result <- list(htmlwidget = p)
     class(result) <- "StandardChart"
     if (n.variables == 1)

--- a/R/linechart.R
+++ b/R/linechart.R
@@ -465,7 +465,7 @@ Line <-   function(x,
         hoverlabel = list(namelength = -1, bordercolor = "transparent",
             font = list(size = hovertext.font.size, family = hovertext.font.family))
     )
-    #attr(p, "can-run-in-root-dom") <- TRUE
+    attr(p, "can-run-in-root-dom") <- TRUE
     result <- list(htmlwidget = p)
     class(result) <- "StandardChart"
     attr(result, "ChartType") <- if (all(marker.show)) "Line Markers" else "Line"

--- a/R/pyramid.R
+++ b/R/pyramid.R
@@ -269,7 +269,7 @@ Pyramid <- function(x,
         bargap = bar.gap,
         barmode = 'overlay'
     )
-    #attr(p, "can-run-in-root-dom") <- TRUE
+    attr(p, "can-run-in-root-dom") <- TRUE
     result <- list(htmlwidget = p)
     class(result) <- "StandardChart"
     attr(result, "ChartType") <- "Bar Clustered"

--- a/R/radarchart.R
+++ b/R/radarchart.R
@@ -398,7 +398,7 @@ Radar <- function(x,
 
     p <- config(p, displayModeBar = modebar.show)
     p$sizingPolicy$browser$padding <- 0
-    #attr(p, "can-run-in-root-dom") <- TRUE
+    attr(p, "can-run-in-root-dom") <- TRUE
     result <- list(htmlwidget = p)
     class(result) <- "StandardChart"
     attr(result, "ChartType") <- "Radar Filled"

--- a/R/scatterchart.R
+++ b/R/scatterchart.R
@@ -775,7 +775,7 @@ Scatter <- function(x = NULL,
         hoverlabel = list(namelength = -1, bordercolor = "transparent",
             font = list(size = hovertext.font.size, family = hovertext.font.family))
     )
-    #attr(p, "can-run-in-root-dom") <- TRUE
+    attr(p, "can-run-in-root-dom") <- TRUE
     result <- list(htmlwidget = p)
     class(result) <- "StandardChart"
     attr(result, "ChartType") <- if (!is.null(scatter.sizes)) "Bubble"

--- a/R/smallmultiples.R
+++ b/R/smallmultiples.R
@@ -555,7 +555,7 @@ SmallMultiples <- function(x,
     margins$autoexpand <- margin.autoexpand
     res <- layout(res, showlegend = is.geo, margin = margins,
                   annotations = annotations)
-    ##attr(res, "can-run-in-root-dom") <- TRUE  RS-7009
+    attr(res, "can-run-in-root-dom") <- TRUE
     result <- list(htmlwidget = res)
     class(result) <- "StandardChart"
     attr(result, "ChartType") <- switch(chart.type,

--- a/R/sparkline.R
+++ b/R/sparkline.R
@@ -290,7 +290,7 @@ Sparkline <- function(x,
 			family = hover.font.family)),
         plot_bgcolor = "transparent",
         paper_bgcolor = toRGB(background.fill.color, alpha = background.fill.opacity))
-    #attr(p, "can-run-in-root-dom") <- TRUE
+    attr(p, "can-run-in-root-dom") <- TRUE
     result <- list(htmlwidget = p)
     class(result) <- "StandardChart"
     result

--- a/R/stackedcolumnannot.R
+++ b/R/stackedcolumnannot.R
@@ -901,7 +901,7 @@ StackedColumnWithStatisticalSignificance <- function(x,
         bargap = bar.gap,
         barmode = barmode
     )
-    #attr(p, "can-run-in-root-dom") <- TRUE
+    attr(p, "can-run-in-root-dom") <- TRUE
     result <- list(htmlwidget = p)
     class(result) <- "StandardChart"
     attr(result, "ChartType") <- "Column Stacked"


### PR DESCRIPTION
Now that plotly is fixed, and iframeless areachart has appeared to work correctly, convert all standard charts to iframeless