### PR TITLE
DS-3236: Check there is no extra percentage sign

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipStandardCharts
 Type: Package
 Title: Standard R interactive charts
-Version: 1.19.7
+Version: 1.19.8
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other charting packages. The goal is to provide a

--- a/R/areachart.R
+++ b/R/areachart.R
@@ -169,23 +169,10 @@ Area <- function(x,
         if (isAutoFormat(data.label.format))
             data.label.format <- paste0(data.label.format, "%")
 
-        extra.percent <- FALSE
-        if (checkSuffixForExtraPercent(y.tick.suffix, y.tick.format))
-        {
-            y.tick.suffix <- sub("%", "", y.tick.suffix)
-            extra.percent <- TRUE
-        }
-        if (checkSuffixForExtraPercent(data.label.suffix, data.label.format))
-        {
-            data.label.suffix <- sub("%", "", data.label.suffix)
-            extra.percent <- TRUE
-        }
-
-        # Only show warning once
-        if (extra.percent)
-            warning("A percentage sign is automatically added to percent data. ",
-                "The first '%' in the suffix will be ignored.")
-
+        sfx <- checkSuffixForExtraPercent(c(y.tick.suffix, data.label.suffix),
+            c(y.tick.format, data.label.format))
+        y.tick.suffix <- sfx[1]
+        data.label.suffix <- sfx[2]
     }
 
     chart.matrix <- checkMatrixNames(x)

--- a/R/areachart.R
+++ b/R/areachart.R
@@ -168,6 +168,24 @@ Area <- function(x,
             y.hovertext.format <- paste0(y.hovertext.format, "%")
         if (isAutoFormat(data.label.format))
             data.label.format <- paste0(data.label.format, "%")
+
+        extra.percent <- FALSE
+        if (checkSuffixForExtraPercent(y.tick.suffix, y.tick.format))
+        {
+            y.tick.suffix <- sub("%", "", y.tick.suffix)
+            extra.percent <- TRUE
+        }
+        if (checkSuffixForExtraPercent(data.label.suffix, data.label.format))
+        {
+            data.label.suffix <- sub("%", "", data.label.suffix)
+            extra.percent <- TRUE
+        }
+
+        # Only show warning once
+        if (extra.percent)
+            warning("A percentage sign is automatically added to percent data. ",
+                "The first '%' in the suffix will be ignored.")
+
     }
 
     chart.matrix <- checkMatrixNames(x)

--- a/R/barchart.R
+++ b/R/barchart.R
@@ -166,25 +166,11 @@ Bar <- function(x,
         if (isAutoFormat(data.label.format))
             data.label.format <- paste0(data.label.format, "%")
 
-        extra.percent <- FALSE
-        if (checkSuffixForExtraPercent(x.tick.suffix, x.tick.format))
-        {
-            x.tick.suffix <- sub("%", "", x.tick.suffix)
-            extra.percent <- TRUE
-        }
-        if (checkSuffixForExtraPercent(data.label.suffix, data.label.format))
-        {
-            data.label.suffix <- sub("%", "", data.label.suffix)
-            extra.percent <- TRUE
-        }
-
-        # Only show warning once
-        if (extra.percent)
-            warning("A percentage sign is automatically added to percent data. ",
-                "The first '%' in the suffix will be ignored.")
-
+        sfx <- checkSuffixForExtraPercent(c(x.tick.suffix, data.label.suffix),
+            c(x.tick.format, data.label.format))
+        x.tick.suffix <- sfx[1]
+        data.label.suffix <- sfx[2]
     }
-
 
     chart.matrix <- checkMatrixNames(x)
     is.stacked <- grepl("Stacked", type, fixed=T)

--- a/R/barchart.R
+++ b/R/barchart.R
@@ -165,6 +165,24 @@ Bar <- function(x,
             x.hovertext.format <- paste0(x.hovertext.format, "%")
         if (isAutoFormat(data.label.format))
             data.label.format <- paste0(data.label.format, "%")
+
+        extra.percent <- FALSE
+        if (checkSuffixForExtraPercent(x.tick.suffix, x.tick.format))
+        {
+            x.tick.suffix <- sub("%", "", x.tick.suffix)
+            extra.percent <- TRUE
+        }
+        if (checkSuffixForExtraPercent(data.label.suffix, data.label.format))
+        {
+            data.label.suffix <- sub("%", "", data.label.suffix)
+            extra.percent <- TRUE
+        }
+
+        # Only show warning once
+        if (extra.percent)
+            warning("A percentage sign is automatically added to percent data. ",
+                "The first '%' in the suffix will be ignored.")
+
     }
 
 

--- a/R/barmulticolor.R
+++ b/R/barmulticolor.R
@@ -120,23 +120,10 @@ BarMultiColor <- function(x,
         if (isAutoFormat(data.label.format))
             data.label.format <- paste0(data.label.format, "%")
 
-        extra.percent <- FALSE
-        if (checkSuffixForExtraPercent(x.tick.suffix, x.tick.format))
-        {
-            x.tick.suffix <- sub("%", "", x.tick.suffix)
-            extra.percent <- TRUE
-        }
-        if (checkSuffixForExtraPercent(data.label.suffix, data.label.format))
-        {
-            data.label.suffix <- sub("%", "", data.label.suffix)
-            extra.percent <- TRUE
-        }
-
-        # Only show warning once
-        if (extra.percent)
-            warning("A percentage sign is automatically added to percent data. ",
-                "The first '%' in the suffix will be ignored.")
-
+        sfx <- checkSuffixForExtraPercent(c(x.tick.suffix, data.label.suffix),
+            c(x.tick.format, data.label.format))
+        x.tick.suffix <- sfx[1]
+        data.label.suffix <- sfx[2]
 
     }
 

--- a/R/barmulticolor.R
+++ b/R/barmulticolor.R
@@ -119,6 +119,25 @@ BarMultiColor <- function(x,
             x.hovertext.format <- paste0(x.hovertext.format, "%")
         if (isAutoFormat(data.label.format))
             data.label.format <- paste0(data.label.format, "%")
+
+        extra.percent <- FALSE
+        if (checkSuffixForExtraPercent(x.tick.suffix, x.tick.format))
+        {
+            x.tick.suffix <- sub("%", "", x.tick.suffix)
+            extra.percent <- TRUE
+        }
+        if (checkSuffixForExtraPercent(data.label.suffix, data.label.format))
+        {
+            data.label.suffix <- sub("%", "", data.label.suffix)
+            extra.percent <- TRUE
+        }
+
+        # Only show warning once
+        if (extra.percent)
+            warning("A percentage sign is automatically added to percent data. ",
+                "The first '%' in the suffix will be ignored.")
+
+
     }
 
     chart.matrix <- checkMatrixNames(x)

--- a/R/chartutils.R
+++ b/R/chartutils.R
@@ -1517,9 +1517,21 @@ isPercentData <- function(data)
 {
     if (isTRUE(grepl("%", attr(data, "statistic"))))
         return(TRUE)
-    ndim <- length(dim(data))    
-    if (is.null(attr(data, "statistic")) && 
+    ndim <- length(dim(data))
+    if (is.null(attr(data, "statistic")) &&
         isTRUE(grepl("%", dimnames(data)[[ndim]][1])))
         return(TRUE)
     return(FALSE)
+}
+
+# y.tick.format, y.hovertext.format, y2.tick.format, y2.hovertext.format
+# data.label.format
+
+checkSuffixForExtraPercent <- function(suffix, format)
+{
+    if (isTRUE(grepl("%", format)) && isTRUE(grepl("%", suffix)))
+        return(TRUE)
+    else
+        return(FALSE)
+
 }

--- a/R/chartutils.R
+++ b/R/chartutils.R
@@ -1526,12 +1526,16 @@ isPercentData <- function(data)
 
 # y.tick.format, y.hovertext.format, y2.tick.format, y2.hovertext.format
 # data.label.format
-
 checkSuffixForExtraPercent <- function(suffix, format)
 {
-    if (isTRUE(grepl("%", format)) && isTRUE(grepl("%", suffix)))
-        return(TRUE)
-    else
-        return(FALSE)
-
+    new.suffix <- suffix
+    for (i in seq_along(suffix))
+    {
+        if (isTRUE(grepl("%", format[i])) && isTRUE(grepl("%", suffix[i])))
+            new.suffix[i] <- sub("%", "", suffix[i])
+    }
+    if (any(new.suffix != suffix))
+        warning("A percentage sign is automatically added to percent data. ",
+            "The first '%' in the suffix will be ignored.")
+    return(new.suffix)
 }

--- a/R/columnchart.R
+++ b/R/columnchart.R
@@ -490,6 +490,23 @@ Column <- function(x,
             y.hovertext.format <- paste0(y.hovertext.format, "%")
         if (isAutoFormat(data.label.format))
             data.label.format <- paste0(data.label.format, "%")
+
+        extra.percent <- FALSE
+        if (checkSuffixForExtraPercent(y.tick.suffix, y.tick.format))
+        {
+            y.tick.suffix <- sub("%", "", y.tick.suffix)
+            extra.percent <- TRUE
+        }
+        if (checkSuffixForExtraPercent(data.label.suffix, data.label.format))
+        {
+            data.label.suffix <- sub("%", "", data.label.suffix)
+            extra.percent <- TRUE
+        }
+
+        # Only show warning once
+        if (extra.percent)
+            warning("A percentage sign is automatically added to percent data. ",
+                "The first '%' in the suffix will be ignored.")
     }
 
     if (bar.gap < 0.0 || bar.gap >= 1.0)
@@ -625,6 +642,35 @@ Column <- function(x,
     x.all.labels <- x.labels
     if (!is.null(x2))
     {
+
+        if (isPercentData(x2))
+        {
+            if (isAutoFormat(y2.tick.format))
+                y2.tick.format <- paste0(y2.tick.format, "%")
+            if (isAutoFormat(y2.hovertext.format))
+                y2.hovertext.format <- paste0(y2.hovertext.format, "%")
+            if (isAutoFormat(data.label.format))
+                x2.data.label.format <- paste0(data.label.format, "%")
+
+            extra.percent <- FALSE
+            if (checkSuffixForExtraPercent(y2.tick.suffix, y2.tick.format))
+            {
+                y2.tick.suffix <- sub("%", "", y2.tick.suffix)
+                extra.percent <- TRUE
+            }
+            if (checkSuffixForExtraPercent(x2.data.label.suffix, x2.data.label.format))
+            {
+                x2.data.label.suffix <- sub("%", "", x2.data.label.suffix)
+                extra.percent <- TRUE
+            }
+            # Only show warning once
+            if (extra.percent)
+                warning("A percentage sign is automatically added to percent data. ",
+                    "The first '%' in the suffix will be ignored.")
+
+        }
+
+
         # Set up x-axis values for x2
         x2 <- checkMatrixNames(x2)
         x2.axis.type <- getAxisType(rownames(x2), format = x.tick.format)

--- a/R/columnchart.R
+++ b/R/columnchart.R
@@ -491,22 +491,10 @@ Column <- function(x,
         if (isAutoFormat(data.label.format))
             data.label.format <- paste0(data.label.format, "%")
 
-        extra.percent <- FALSE
-        if (checkSuffixForExtraPercent(y.tick.suffix, y.tick.format))
-        {
-            y.tick.suffix <- sub("%", "", y.tick.suffix)
-            extra.percent <- TRUE
-        }
-        if (checkSuffixForExtraPercent(data.label.suffix, data.label.format))
-        {
-            data.label.suffix <- sub("%", "", data.label.suffix)
-            extra.percent <- TRUE
-        }
-
-        # Only show warning once
-        if (extra.percent)
-            warning("A percentage sign is automatically added to percent data. ",
-                "The first '%' in the suffix will be ignored.")
+        sfx <- checkSuffixForExtraPercent(c(y.tick.suffix, data.label.suffix),
+            c(y.tick.format, data.label.format))
+        y.tick.suffix <- sfx[1]
+        data.label.suffix <- sfx[2]
     }
 
     if (bar.gap < 0.0 || bar.gap >= 1.0)
@@ -642,7 +630,6 @@ Column <- function(x,
     x.all.labels <- x.labels
     if (!is.null(x2))
     {
-
         if (isPercentData(x2))
         {
             if (isAutoFormat(y2.tick.format))
@@ -651,25 +638,12 @@ Column <- function(x,
                 y2.hovertext.format <- paste0(y2.hovertext.format, "%")
             if (isAutoFormat(data.label.format))
                 x2.data.label.format <- paste0(data.label.format, "%")
-
-            extra.percent <- FALSE
-            if (checkSuffixForExtraPercent(y2.tick.suffix, y2.tick.format))
-            {
-                y2.tick.suffix <- sub("%", "", y2.tick.suffix)
-                extra.percent <- TRUE
-            }
-            if (checkSuffixForExtraPercent(x2.data.label.suffix, x2.data.label.format))
-            {
-                x2.data.label.suffix <- sub("%", "", x2.data.label.suffix)
-                extra.percent <- TRUE
-            }
-            # Only show warning once
-            if (extra.percent)
-                warning("A percentage sign is automatically added to percent data. ",
-                    "The first '%' in the suffix will be ignored.")
-
+        
+            sfx <- checkSuffixForExtraPercent(c(y2.tick.suffix, x2.data.label.suffix),
+                c(y2.tick.format, x2.data.label.format))
+            y2.tick.suffix <- sfx[1]
+            x2.data.label.suffix <- sfx[2]
         }
-
 
         # Set up x-axis values for x2
         x2 <- checkMatrixNames(x2)

--- a/R/columnmulticolor.R
+++ b/R/columnmulticolor.R
@@ -120,23 +120,10 @@ ColumnMultiColor <- function(x,
         if (isAutoFormat(data.label.format))
             data.label.format <- paste0(data.label.format, "%")
 
-        extra.percent <- FALSE
-        if (checkSuffixForExtraPercent(y.tick.suffix, y.tick.format))
-        {
-            y.tick.suffix <- sub("%", "", y.tick.suffix)
-            extra.percent <- TRUE
-        }
-        if (checkSuffixForExtraPercent(data.label.suffix, data.label.format))
-        {
-            data.label.suffix <- sub("%", "", data.label.suffix)
-            extra.percent <- TRUE
-        }
-
-        # Only show warning once
-        if (extra.percent)
-            warning("A percentage sign is automatically added to percent data. ",
-                "The first '%' in the suffix will be ignored.")
-
+        sfx <- checkSuffixForExtraPercent(c(y.tick.suffix, data.label.suffix),
+            c(y.tick.format, data.label.format))
+        y.tick.suffix <- sfx[1]
+        data.label.suffix <- sfx[2]
     }
 
     chart.matrix <- checkMatrixNames(x)

--- a/R/columnmulticolor.R
+++ b/R/columnmulticolor.R
@@ -119,6 +119,24 @@ ColumnMultiColor <- function(x,
             y.hovertext.format <- paste0(y.hovertext.format, "%")
         if (isAutoFormat(data.label.format))
             data.label.format <- paste0(data.label.format, "%")
+
+        extra.percent <- FALSE
+        if (checkSuffixForExtraPercent(y.tick.suffix, y.tick.format))
+        {
+            y.tick.suffix <- sub("%", "", y.tick.suffix)
+            extra.percent <- TRUE
+        }
+        if (checkSuffixForExtraPercent(data.label.suffix, data.label.format))
+        {
+            data.label.suffix <- sub("%", "", data.label.suffix)
+            extra.percent <- TRUE
+        }
+
+        # Only show warning once
+        if (extra.percent)
+            warning("A percentage sign is automatically added to percent data. ",
+                "The first '%' in the suffix will be ignored.")
+
     }
 
     chart.matrix <- checkMatrixNames(x)

--- a/R/linechart.R
+++ b/R/linechart.R
@@ -175,23 +175,10 @@ Line <-   function(x,
         if (isAutoFormat(data.label.format))
             data.label.format <- paste0(data.label.format, "%")
 
-        extra.percent <- FALSE
-        if (checkSuffixForExtraPercent(y.tick.suffix, y.tick.format))
-        {
-            y.tick.suffix <- sub("%", "", y.tick.suffix)
-            extra.percent <- TRUE
-        }
-        if (checkSuffixForExtraPercent(data.label.suffix, data.label.format))
-        {
-            data.label.suffix <- sub("%", "", data.label.suffix)
-            extra.percent <- TRUE
-        }
-
-        # Only show warning once
-        if (extra.percent)
-            warning("A percentage sign is automatically added to percent data. ",
-                "The first '%' in the suffix will be ignored.")
-
+        sfx <- checkSuffixForExtraPercent(c(y.tick.suffix, data.label.suffix),
+            c(y.tick.format, data.label.format))
+        y.tick.suffix <- sfx[1]
+        data.label.suffix <- sfx[2]
     }
 
 

--- a/R/linechart.R
+++ b/R/linechart.R
@@ -174,6 +174,24 @@ Line <-   function(x,
             y.hovertext.format <- paste0(y.hovertext.format, "%")
         if (isAutoFormat(data.label.format))
             data.label.format <- paste0(data.label.format, "%")
+
+        extra.percent <- FALSE
+        if (checkSuffixForExtraPercent(y.tick.suffix, y.tick.format))
+        {
+            y.tick.suffix <- sub("%", "", y.tick.suffix)
+            extra.percent <- TRUE
+        }
+        if (checkSuffixForExtraPercent(data.label.suffix, data.label.format))
+        {
+            data.label.suffix <- sub("%", "", data.label.suffix)
+            extra.percent <- TRUE
+        }
+
+        # Only show warning once
+        if (extra.percent)
+            warning("A percentage sign is automatically added to percent data. ",
+                "The first '%' in the suffix will be ignored.")
+
     }
 
 

--- a/R/palm.R
+++ b/R/palm.R
@@ -64,12 +64,7 @@ Palm <- function(table,
     if (isPercentData(table) && isAutoFormat(y.tick.format))
     {
         y.tick.format <- paste0(y.tick.format, "%")
-        if (checkSuffixForExtraPercent(y.tick.suffix, y.tick.format))
-        {
-            y.tick.suffix <- sub("%", "", y.tick.suffix)
-            warning("A percentage sign is automatically added to percent data. ",
-                "The first '%' in the suffix will be ignored.")
-        }
+        y.tick.suffix <- checkSuffixForExtraPercent(y.tick.suffix, y.tick.format)
     }
     table <- checkMatrixNames(table)
 

--- a/R/palm.R
+++ b/R/palm.R
@@ -62,7 +62,15 @@ Palm <- function(table,
     ErrorIfNotEnoughData(table)
     stat <- attr(table, "statistic")
     if (isPercentData(table) && isAutoFormat(y.tick.format))
+    {
         y.tick.format <- paste0(y.tick.format, "%")
+        if (checkSuffixForExtraPercent(y.tick.suffix, y.tick.format))
+        {
+            y.tick.suffix <- sub("%", "", y.tick.suffix)
+            warning("A percentage sign is automatically added to percent data. ",
+                "The first '%' in the suffix will be ignored.")
+        }
+    }
     table <- checkMatrixNames(table)
 
     #  Automatic formatting with statistic of '%'

--- a/R/pyramid.R
+++ b/R/pyramid.R
@@ -115,6 +115,25 @@ Pyramid <- function(x,
             x.hovertext.format <- paste0(x.hovertext.format, "%")
         if (isAutoFormat(data.label.format))
             data.label.format <- paste0(data.label.format, "%")
+
+        extra.percent <- FALSE
+        if (checkSuffixForExtraPercent(x.tick.suffix, x.tick.format))
+        {
+            x.tick.suffix <- sub("%", "", x.tick.suffix)
+            extra.percent <- TRUE
+        }
+        if (checkSuffixForExtraPercent(data.label.suffix, data.label.format))
+        {
+            data.label.suffix <- sub("%", "", data.label.suffix)
+            extra.percent <- TRUE
+        }
+
+        # Only show warning once
+        if (extra.percent)
+            warning("A percentage sign is automatically added to percent data. ",
+                "The first '%' in the suffix will be ignored.")
+
+
     }
     chart.matrix <- checkMatrixNames(x)
     if (NROW(chart.matrix) == 1 && NCOL(chart.matrix) > 1)

--- a/R/pyramid.R
+++ b/R/pyramid.R
@@ -116,24 +116,10 @@ Pyramid <- function(x,
         if (isAutoFormat(data.label.format))
             data.label.format <- paste0(data.label.format, "%")
 
-        extra.percent <- FALSE
-        if (checkSuffixForExtraPercent(x.tick.suffix, x.tick.format))
-        {
-            x.tick.suffix <- sub("%", "", x.tick.suffix)
-            extra.percent <- TRUE
-        }
-        if (checkSuffixForExtraPercent(data.label.suffix, data.label.format))
-        {
-            data.label.suffix <- sub("%", "", data.label.suffix)
-            extra.percent <- TRUE
-        }
-
-        # Only show warning once
-        if (extra.percent)
-            warning("A percentage sign is automatically added to percent data. ",
-                "The first '%' in the suffix will be ignored.")
-
-
+        sfx <- checkSuffixForExtraPercent(c(x.tick.suffix, data.label.suffix),
+            c(x.tick.format, data.label.format))
+        x.tick.suffix <- sfx[1]
+        data.label.suffix <- sfx[2]
     }
     chart.matrix <- checkMatrixNames(x)
     if (NROW(chart.matrix) == 1 && NCOL(chart.matrix) > 1)

--- a/R/radarchart.R
+++ b/R/radarchart.R
@@ -121,6 +121,24 @@ Radar <- function(x,
             y.hovertext.format <- paste0(y.hovertext.format, "%")
         if (isAutoFormat(data.label.format))
             data.label.format <- paste0(data.label.format, "%")
+
+        extra.percent <- FALSE
+        if (checkSuffixForExtraPercent(y.tick.suffix, y.tick.format))
+        {
+            y.tick.suffix <- sub("%", "", y.tick.suffix)
+            extra.percent <- TRUE
+        }
+        if (checkSuffixForExtraPercent(data.label.suffix, data.label.format))
+        {
+            data.label.suffix <- sub("%", "", data.label.suffix)
+            extra.percent <- TRUE
+        }
+
+        # Only show warning once
+        if (extra.percent)
+            warning("A percentage sign is automatically added to percent data. ",
+                "The first '%' in the suffix will be ignored.")
+
     }
 
     chart.matrix <- checkMatrixNames(x)

--- a/R/radarchart.R
+++ b/R/radarchart.R
@@ -122,23 +122,10 @@ Radar <- function(x,
         if (isAutoFormat(data.label.format))
             data.label.format <- paste0(data.label.format, "%")
 
-        extra.percent <- FALSE
-        if (checkSuffixForExtraPercent(y.tick.suffix, y.tick.format))
-        {
-            y.tick.suffix <- sub("%", "", y.tick.suffix)
-            extra.percent <- TRUE
-        }
-        if (checkSuffixForExtraPercent(data.label.suffix, data.label.format))
-        {
-            data.label.suffix <- sub("%", "", data.label.suffix)
-            extra.percent <- TRUE
-        }
-
-        # Only show warning once
-        if (extra.percent)
-            warning("A percentage sign is automatically added to percent data. ",
-                "The first '%' in the suffix will be ignored.")
-
+        sfx <- checkSuffixForExtraPercent(c(y.tick.suffix, data.label.suffix),
+            c(y.tick.format, data.label.format))
+        y.tick.suffix <- sfx[1]
+        data.label.suffix <- sfx[2]
     }
 
     chart.matrix <- checkMatrixNames(x)

--- a/R/stackedcolumnannot.R
+++ b/R/stackedcolumnannot.R
@@ -258,23 +258,10 @@ StackedColumnWithStatisticalSignificance <- function(x,
         if (isAutoFormat(data.label.format))
             data.label.format <- paste0(data.label.format, "%")
 
-        extra.percent <- FALSE
-        if (checkSuffixForExtraPercent(y.tick.suffix, y.tick.format))
-        {
-            y.tick.suffix <- sub("%", "", y.tick.suffix)
-            extra.percent <- TRUE
-        }
-        if (checkSuffixForExtraPercent(data.label.suffix, data.label.format))
-        {
-            data.label.suffix <- sub("%", "", data.label.suffix)
-            extra.percent <- TRUE
-        }
-
-        # Only show warning once
-        if (extra.percent)
-            warning("A percentage sign is automatically added to percent data. ",
-                "The first '%' in the suffix will be ignored.")
-
+        sfx <- checkSuffixForExtraPercent(c(y.tick.suffix, data.label.suffix),
+            c(y.tick.format, data.label.format))
+        y.tick.suffix <- sfx[1]
+        data.label.suffix <- sfx[2]
     }
 
     # Save data for annotating column totals before

--- a/R/stackedcolumnannot.R
+++ b/R/stackedcolumnannot.R
@@ -257,6 +257,24 @@ StackedColumnWithStatisticalSignificance <- function(x,
             y.hovertext.format <- paste0(y.hovertext.format, "%")
         if (isAutoFormat(data.label.format))
             data.label.format <- paste0(data.label.format, "%")
+
+        extra.percent <- FALSE
+        if (checkSuffixForExtraPercent(y.tick.suffix, y.tick.format))
+        {
+            y.tick.suffix <- sub("%", "", y.tick.suffix)
+            extra.percent <- TRUE
+        }
+        if (checkSuffixForExtraPercent(data.label.suffix, data.label.format))
+        {
+            data.label.suffix <- sub("%", "", data.label.suffix)
+            extra.percent <- TRUE
+        }
+
+        # Only show warning once
+        if (extra.percent)
+            warning("A percentage sign is automatically added to percent data. ",
+                "The first '%' in the suffix will be ignored.")
+
     }
 
     # Save data for annotating column totals before

--- a/tests/testthat/test-bug-ds3236.R
+++ b/tests/testthat/test-bug-ds3236.R
@@ -1,6 +1,6 @@
 # For backwards compatibility, check that we do not add an extra percentage sign
 # to value axis tick labels and data labels
-# (these may have been manually added to the user to work around previous
+# (these may have been manually added by the user to work around previous
 # handling of percentage data)
 
 context("Bug-DS3236")

--- a/tests/testthat/test-bug-ds3236.R
+++ b/tests/testthat/test-bug-ds3236.R
@@ -1,0 +1,49 @@
+# For backwards compatibility, check that we do not add an extra percentage sign
+# to value axis tick labels and data labels
+# (these may have been manually added to the user to work around previous
+# handling of percentage data)
+
+context("Bug-DS2326")
+
+data.with.stats <- structure(c(2.75482093663912, 6.06060606060606, 12.6721763085399,
+18.4573002754821, 24.7933884297521, 15.9779614325069, 6.06060606060606,
+8.26446280991736, 4.95867768595041, 100, 3.77906976744186, 15.9883720930233,
+7.84883720930233, 18.0232558139535, 19.7674418604651, 13.0813953488372,
+10.7558139534884, 4.06976744186047, 6.68604651162791, 100, 3.25318246110325,
+10.8910891089109, 10.3253182461103, 18.2461103253182, 22.3479490806223,
+14.5685997171146, 8.34512022630834, 6.22347949080622, 5.7991513437058,
+100, 0.442913092343004, 0.0000228306627828578, 0.0351514682974756,
+0.881274082835059, 0.108843509396061, 0.275202305069102, 0.0240561692086175,
+0.0210216801333983, 0.326003170694519, NA, 0.442913092343004,
+0.0000228306627828578, 0.0351514682974756, 0.881274082835059,
+0.108843509396061, 0.275202305069102, 0.0240561692086175, 0.0210216801333983,
+0.326003170694519, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA
+), .Dim = c(10L, 3L, 2L), .Dimnames = list(c("Less than $15,000",
+"$15,001 to $30,000", "$30,001 to $45,000", "$45,001 to $60,000",
+"$60,001 to $90,000", "$90,001 to $120,000", "$120,001 to $150,000",
+"$150,001 to $200,000", "$200,001 or more", "NET"), c("Male",
+"Female", "NET"), c("Column %", "p")), name = "Income by Gender", questions = c("Income",
+"Gender"))
+
+test_that("Check for extra percent sign",
+{
+    expect_warning(Palm(data.with.stats[-10,,], y.tick.suffix = "%"),
+                   "A percentage sign is automatically added to ",
+                    "percent data. The first '%' in the suffix will be ignored.")
+
+    for (func in c("Column", "ColumnMultiColor", "Line", "Area", "Radar",
+                    "StackedColumnWithStatisticalSignificance"))
+    {
+        cmd <- paste0("res <- ", func, "(data.with.stats[-10,,], data.label.show = TRUE,",
+                      "data.label.suffix = '%', y.tick.suffix = '%')")
+        expect_warning(eval(parse(text=cmd)), "A percentage sign is automatically added to ",
+                       "percent data. The first '%' in the suffix will be ignored.")
+    }
+
+    for (func in c("Bar", "BarMultiColor", "Pyramid"))
+    {
+        cmd <- paste0("res <- ", func, "(data.with.stats[-10,,], data.label.show = TRUE,",
+                      "data.label.suffix = '%', x.tick.suffix = '%')")
+        expect_warning(eval(parse(text=cmd)))
+    }
+})

--- a/tests/testthat/test-bug-ds3236.R
+++ b/tests/testthat/test-bug-ds3236.R
@@ -3,7 +3,7 @@
 # (these may have been manually added to the user to work around previous
 # handling of percentage data)
 
-context("Bug-DS2326")
+context("Bug-DS3236")
 
 data.with.stats <- structure(c(2.75482093663912, 6.06060606060606, 12.6721763085399,
 18.4573002754821, 24.7933884297521, 15.9779614325069, 6.06060606060606,


### PR DESCRIPTION
This PR checks for an extra percentage sign in the data label suffix and values axis tick labels and removes it (no changes are made to the data).