### PR TITLE
DS-4143: Geographic Maps - Fix hovertext when plotting U.S. regions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipStandardCharts
 Type: Package
 Title: Standard R interactive charts
-Version: 1.30.3
+Version: 1.30.4
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other charting packages. The goal is to provide a

--- a/R/geographicmap.R
+++ b/R/geographicmap.R
@@ -432,12 +432,19 @@ leafletMap <- function(coords, colors, opacity, min.value, max.range, color.NA,
                             data = country.coords)
     }
 
+    ## DS-4143: When plotting U.S.A. regions, override hover text so that
+    ##   it displays U.S. region names instead of state names
+    if (map.type == "regions" && !anyNA(idx <- match(coords$name, us.regions[["State"]])))
+        location.label <- as.character(us.regions[["Region"]][idx])
+    else
+        location.label <- coords$name
+
     if (n.categories == 1)
     {
         map <- addPolygons(map, stroke = FALSE, smoothFactor = 0.2,
                            fillOpacity = opacity, fillColor = ~.pal(coords$table1),
                            highlightOptions = highlight.options,
-                           label = paste0(coords$name, ": ", format.function(coords$table1,
+                           label = paste0(location.label, ": ", format.function(coords$table1,
                                                                              decimals = decimals,
                                                                              comma.for.thousands = commaFromD3(values.hovertext.format))))
         categoryControls <- ""
@@ -450,7 +457,7 @@ leafletMap <- function(coords, colors, opacity, min.value, max.range, color.NA,
             map <- addPolygons(map, stroke = FALSE, smoothFactor = 0.2,
                                fillOpacity = opacity, color = cl, group = categories[i],
                                highlightOptions = highlight.options,
-                               label = paste0(coords$name, ": ",
+                               label = paste0(location.label, ": ",
                                               format.function(coords[[paste("table", i, sep = "")]],
                                                               decimals = decimals,
                                                               comma.for.thousands = commaFromD3(values.hovertext.format))))

--- a/R/updaterda.R
+++ b/R/updaterda.R
@@ -266,9 +266,9 @@
 #                                             "Michigan", "Minnesota", "Mississippi", "Missouri", "Montana", "Nebraska", "Nevada", "New Hampshire", "New Jersey", "New Mexico",
 #                                             "New York", "North Carolina", "North Dakota", "Ohio", "Oklahoma", "Oregon", "Pennsylvania", "Rhode Island", "South Carolina",
 #                                             "South Dakota", "Tennessee", "Texas", "Utah", "Vermont", "Virginia", "Washington", "West Virginia", "Wisconsin", "Wyoming"), class = "factor"),
-#                             Code = structure(c(7L, 21L, 19L, 30L, 39L, 46L, 31L, 34L, 38L, 21L, 15L, 22L, 35L, 48L, 13L, 16L, 23L, 24L, 29L, 28L, 41L, 9L, 10L,
-#                                             11L, 20L, 27L, 40L, 45L, 8L, 49L, 2L, 17L, 25L, 42L, 3L, 18L, 36L, 43L, 4L, 6L, 14L, 26L, 33L, 32L, 44L, 50L, 1L, 5L, 12L, 37L, 47L),
-#                                             .Label = c("AK","AL", "AR", "AZ", "CA", "CO", "CT", "DC", "DE", "FL", "GA", "HI", "IA", "ID", "IN", "KS", "KY", "LA", "MA", "MD", "ME",
+#                             Code = structure(c(7L, 22L, 20L, 31L, 40L, 47L, 32L, 35L, 39L, 15L, 16L, 23L, 36L, 49L, 13L, 17L, 24L, 25L, 30L, 29L, 42L, 9L, 10L,
+#                                             11L, 21L, 28L, 41L, 46L, 8L, 50L, 2L, 18L, 26L, 43L, 3L, 19L, 37L, 44L, 4L, 6L, 14L, 27L, 34L, 33L, 45L, 51L, 1L, 5L, 12L, 38L, 48L),
+#                                             .Label = c("AK","AL", "AR", "AZ", "CA", "CO", "CT", "DC", "DE", "FL", "GA", "HI", "IA", "ID", "IL", "IN", "KS", "KY", "LA", "MA", "MD", "ME",
 #                                             "MI", "MN", "MO", "MS", "MT", "NC", "ND", "NE", "NH", "NJ", "NM", "NV", "NY", "OH", "OK", "OR", "PA", "RI", "SC", "SD", "TN", "TX", "UT", "VA", "VT", "WA", "WI", "WV", "WY"), class = "factor")),
 #                         .Names = c("RegionNumber", "DivisionNumber", "Region", "Division", "State", "Code"), row.names = c(NA, 51L), class = "data.frame")
 
@@ -378,7 +378,7 @@
 # # unnecessarily large (I'm guessing R stores a very large
 # # environment with one of the SpatialPolygonsDataFrame objects)
 # # which was making sysdata.rda >100MB
-# save(missing110,
+## save(missing110,
 #      admin1.name.map,
 #      admin0.name.map.by.admin,
 #      admin1.coordinates,


### PR DESCRIPTION
* Update/override hovertext in `leafletMap` and `plotlyMap` when the user has supplied U.S. regions to `GeographicMap` so that they display U.S. region names instead of U.S. state names (matching the supplied data)
* Fix bug with `us.regions` data.frame in `R/sysdata.rda`: the "Code" (two-letter state abbreviation) for Illinois was incorrectly entered as `"ME"` instead of `"IL"`.