### PR TITLE
RS-13816: adjust polygons as well as default zoom to wrap around antimeridian

### DIFF
--- a/R/geographicmap.R
+++ b/R/geographicmap.R
@@ -390,7 +390,8 @@ leafletMap <- function(coords, colors, opacity, min.value, max.range, color.NA,
         max.values <- c(max.values, max.values * 1.1)
 
     # If we are close to the anti meridian, wrap coords and polygons
-    if ("longitude" %in% colnames(coords@data)) {
+    if ("longitude" %in% colnames(coords@data) && map.type != "United States of America" &&
+        map.type != "regions") {
         lng <- coords@data$longitude
         if (any(lng > 170)) {
             .wrapAntiMeridian <- function(x) ifelse(x < 0, 360 + x, x)

--- a/R/geographicmap.R
+++ b/R/geographicmap.R
@@ -388,8 +388,8 @@ leafletMap <- function(coords, colors, opacity, min.value, max.range, color.NA,
     max.values <- unique(coords$table.max[!is.na(coords$table.max)])
     if (length(max.values) == 1)
         max.values <- c(max.values, max.values * 1.1)
-    
-    # If we are close to the antimeridian, wrap coords and polygons
+
+    # If we are close to the anti meridian, wrap coords and polygons
     if ("longitude" %in% colnames(coords@data)) {
         lng <- coords@data$longitude
         if (any(lng > 170)) {
@@ -489,7 +489,7 @@ leafletMap <- function(coords, colors, opacity, min.value, max.range, color.NA,
         map <- setView(map, -96, 37.8, zoom = 4)
     } else if ("longitude" %in% colnames(coords@data)) {
 
-        # Manually set zoom if map we are close to the antimeridian
+        # Manually set zoom level if we are close to the anti meridian
         lng <- coords@data$longitude
         ltd <- coords@data$latitude
         if (any(lng > 170)) {


### PR DESCRIPTION
This is to fix the problem where leaflet doesn't realise that longitude 179 is close to longitude -179. Affects the maps for New Zealand, Fiji and Russia