### PR TITLE
DS-4185: Avoid repeated coercion of characters to dates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipStandardCharts
 Type: Package
 Title: Standard R interactive charts
-Version: 1.30.11
+Version: 1.30.12
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other charting packages. The goal is to provide a

--- a/R/timeseries.R
+++ b/R/timeseries.R
@@ -82,8 +82,8 @@ TimeSeries <- function(x = NULL,
     if (is.null(colors))
         colors <- ChartColors(ncol(x))
 
-    row.names <- AsDateTime(rownames(x), on.parse.failure = "silent")
-    if (all(is.na(row.names)))
+    row.names.date <- AsDateTime(rownames(x), on.parse.failure = "silent")
+    if (all(is.na(row.names.date)))
     {
         if (IsRServer())
             stop("Time series charts require dates to be supplied as the row names ",
@@ -92,13 +92,13 @@ TimeSeries <- function(x = NULL,
         else
             stop("Row names of input data could not be interpreted as dates.")
     }
-    is.time <- !all(format(row.names, format = "%H:%M:%S") == "00:00:00")
-    rownames(x) <- as.character(row.names)
+    is.time <- !all(format(row.names.date, format = "%H:%M:%S") == "00:00:00")
+    rownames(x) <- as.character(row.names.date)
 
     # Make sure input data is ordered - this is required for dygraphs
-    ord <- order(row.names)
+    ord <- order(row.names.date)
     x <- x[ord,,drop = FALSE]
-    row.names <- row.names
+    row.names.date <- row.names.date[ord]
 
     if (range.bars)
     {
@@ -111,16 +111,16 @@ TimeSeries <- function(x = NULL,
 
     names(colors) <- NULL # Remove names because named chr is (oddly!) ignored by dygraph
 
-    range.end <- as.POSIXct(row.names[length(row.names)])
+    range.end <- as.POSIXct(row.names.date[length(row.names.date)])
     if (is.null(window.start))
-        range.start <- as.POSIXct(row.names[1])
+        range.start <- as.POSIXct(row.names.date[1])
     else
-        range.start <- max(range.end - 60 * 60 * 24 * window.start, as.POSIXct(row.names[1]))
+        range.start <- max(range.end - 60 * 60 * 24 * window.start, as.POSIXct(row.names.date[1]))
 
     # Convert to an xts object with UTC timezone, or else this is done within dygraph which takes the
     # system timezone, which causes a difference between the data times and the x-axis times.
     if (is.time)
-        x <- xts(x, order.by = row.names, tzone = "UTC")
+        x <- xts(x, order.by = row.names.date, tzone = "UTC")
 
     # Controlling the formatting of the dygraphs via the CSS
     css <- paste0(".dygraph-title {

--- a/R/timeseries.R
+++ b/R/timeseries.R
@@ -98,6 +98,7 @@ TimeSeries <- function(x = NULL,
     # Make sure input data is ordered - this is required for dygraphs
     ord <- order(row.names)
     x <- x[ord,,drop = FALSE]
+    row.names <- row.names
 
     if (range.bars)
     {
@@ -110,16 +111,16 @@ TimeSeries <- function(x = NULL,
 
     names(colors) <- NULL # Remove names because named chr is (oddly!) ignored by dygraph
 
-    range.end <- as.POSIXct(rownames(x)[length(rownames(x))])
+    range.end <- as.POSIXct(row.names[length(row.names)])
     if (is.null(window.start))
-        range.start <- as.POSIXct(rownames(x)[1])
+        range.start <- as.POSIXct(row.names[1])
     else
-        range.start <- max(range.end - 60 * 60 * 24 * window.start, as.POSIXct(rownames(x)[1]))
+        range.start <- max(range.end - 60 * 60 * 24 * window.start, as.POSIXct(row.names[1]))
 
     # Convert to an xts object with UTC timezone, or else this is done within dygraph which takes the
     # system timezone, which causes a difference between the data times and the x-axis times.
     if (is.time)
-        x <- xts(x, order.by = AsDateTime(rownames(x)), tzone = "UTC")
+        x <- xts(x, order.by = row.names, tzone = "UTC")
 
     # Controlling the formatting of the dygraphs via the CSS
     css <- paste0(".dygraph-title {

--- a/R/timeseries.R
+++ b/R/timeseries.R
@@ -93,7 +93,7 @@ TimeSeries <- function(x = NULL,
             stop("Row names of input data could not be interpreted as dates.")
     }
     is.time <- !all(format(row.names.date, format = "%H:%M:%S") == "00:00:00")
-    rownames(x) <- as.character(row.names.date)
+    rownames(x) <- format(row.names.date)
 
     # Make sure input data is ordered - this is required for dygraphs
     ord <- order(row.names.date)

--- a/R/timeseries.R
+++ b/R/timeseries.R
@@ -99,7 +99,7 @@ TimeSeries <- function(x = NULL,
     ord <- order(row.names.date)
     x <- x[ord,,drop = FALSE]
     row.names.date <- row.names.date[ord]
-
+ 
     if (range.bars)
     {
         if (ncol(x) != 3)

--- a/tests/testthat/test-timeseries.R
+++ b/tests/testthat/test-timeseries.R
@@ -142,6 +142,15 @@ test_that("data frame iputs are accepted",
     expect_error(Line(df), NA)
 })
 
+test_that("DS-4185 Zero time stamps in labels handled correctly for R4.3.0", {
+    input.data = matrix(1:5, nrow = 5)
+    rownames(input.data) = c("Jan 12 2007 00:00",
+                             "Jan 12 2007 12:00",
+                             "Jan 13 2007 00:00",
+                             "Jan 13 2007 12:00",
+                             "Jan 14 2007 00:00")
+    expect_error(TimeSeries(input.data), NA)
+})
 
 
 


### PR DESCRIPTION
Applying as.character to a POSIXt object can now strip the time portion of the text if it is identical to 00:00:00. This is new behavior in R4.3.0