### PR TITLE
!untracked: Add strong dependency for sf package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,7 @@ Imports:
     rhtmlLabeledScatter,
     rhtmlPalmTrees,
     rhtmlPictographs,
+    sf,
     sp,
     streamgraph,
     stringr,


### PR DESCRIPTION
sf is required by the deprecation of certain other packages upon which the sp spatial mapping package requires. Adding the dependency should ensure that sp continues to work.