### PR TITLE
FS2-1973: Check for existing dependencies before appending css

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ parameters:
   executor:
     type: enum
     enum: [nightly, rocker, machine,rocker-geo]
-    default: rocker-geo
+    default: nightly
 
 workflows:
   build-and-check-R-package:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipStandardCharts
 Type: Package
 Title: Standard R interactive charts
-Version: 1.30.15
+Version: 1.30.16
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other charting packages. The goal is to provide a
@@ -47,7 +47,6 @@ Imports:
     xml2,
     abind
 Remotes:
-    cran/rgdal@1.5-12,
     Displayr/plotly,
     Displayr/flipU,
     Displayr/flipChartBasics,

--- a/R/geographicmap.R
+++ b/R/geographicmap.R
@@ -539,10 +539,13 @@ leafletMap <- function(coords, colors, opacity, min.value, max.range, color.NA,
     #      attachment = basename(tf),
          all_files = FALSE
     )
-    ## for some reason with v0.3.6 htmltools, attachDependencies(map, dep) doesn't work
-    ## An alternative, less robust way to do this is:
-    ##   htmlwidgets::prependContent(map, tags$style(paste0(css, collapse = "")))
-    map$dependencies <- list(dep)
+    # As of leaflet version 2.2.0, HTML dependencies for leaflet() are included
+    # in the dependencies item of the htmlwidget
+    ndeps <- length(map$dependencies)
+    if (ndeps == 0)
+        map$dependencies <- list(dep)
+    else
+        map$dependencies[[ndeps + 1]] <- dep
 
     return(map)
 }


### PR DESCRIPTION
This PR fixes the blank output caused be updating leaflet from version 2.1.2 to 2.2.0. It is caused by this change: https://github.com/rstudio/leaflet/pull/817