### PR TITLE
FS2-2716: automatically populate legend.title

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipStandardCharts
 Type: Package
 Title: Standard R interactive charts
-Version: 1.31.2
+Version: 1.31.3
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other charting packages. The goal is to provide a

--- a/R/combinedscatterplot.R
+++ b/R/combinedscatterplot.R
@@ -21,6 +21,7 @@
 #' @param legend.bubble.font.color Font color of the bubble legend
 #' @param legend.bubble.font.family Font family of the bubble legend
 #' @param legend.bubble.font.size Font size of the bubble legend
+#' @param legend.bubble.title Title to show above the bubble legend
 #' @param legend.bubble.title.font.color Font color of the bubble legend title
 #' @param legend.bubble.title.font.family Font family of the bubble legend title
 #' @param legend.bubble.title.font.size Font size of the bubble legend title
@@ -115,6 +116,7 @@ CombinedScatter <- function(x = NULL,
                             legend.title.font.color = global.font.color,
                             legend.title.font.family = global.font.family,
                             legend.title.font.size = 12,
+                            legend.bubble.title = "",
                             legend.bubble.font.color = global.font.color,
                             legend.bubble.font.family = global.font.family,
                             legend.bubble.font.size = 10,
@@ -383,6 +385,8 @@ CombinedScatter <- function(x = NULL,
         color.scale <- colors
     if (!any(nzchar(legend.title)) && !is.null(scatter.colors))
         legend.title = scatter.colors.name
+    if (!any(nzchar(legend.bubble.title)) && !is.null(scatter.sizes))
+        legend.bubble.title = scatter.sizes.name
 
     p <- rhtmlCombinedScatter::CombinedScatter(
         X = x[not.na],
@@ -476,7 +480,7 @@ CombinedScatter <- function(x = NULL,
         x.title.font.family = x.title.font.family,
         x.title.font.color = x.title.font.color,
         x.title.font.size = x.title.font.size,
-        z.title = scatter.sizes.name,
+        z.title = legend.bubble.title,
         x.format = x.tick.format,
         y.format = y.tick.format,
         x.hover.format = x.hovertext.format,

--- a/man/CombinedScatter.Rd
+++ b/man/CombinedScatter.Rd
@@ -10,13 +10,13 @@ CombinedScatter(
   scatter.x.column = 1,
   scatter.y.column = 2,
   scatter.labels = NULL,
-  scatter.labels.name = NULL,
+  scatter.labels.name = "",
   scatter.sizes = NULL,
-  scatter.sizes.name = NULL,
+  scatter.sizes.name = "",
   scatter.sizes.column = 3,
   scatter.sizes.as.diameter = FALSE,
   scatter.colors = NULL,
-  scatter.colors.name = NULL,
+  scatter.colors.name = "",
   scatter.colors.column = 4,
   scatter.colors.as.categorical = TRUE,
   scatter.groups = NULL,
@@ -358,11 +358,11 @@ Values range from -0.5 (left) to 1.5 (right).}
 
 \item{legend.bubble.font.size}{Font size of the bubble legend}
 
-\item{legend.bubble.title.font.color}{Font color of the bubble legend}
+\item{legend.bubble.title.font.color}{Font color of the bubble legend title}
 
-\item{legend.bubble.title.font.family}{Font color of the bubble legend}
+\item{legend.bubble.title.font.family}{Font family of the bubble legend title}
 
-\item{legend.bubble.title.font.size}{Font color of the bubble legend}
+\item{legend.bubble.title.font.size}{Font size of the bubble legend title}
 
 \item{margin.autoexpand}{Logical; Whether extra space can be added to the margins
 to allow space for axis/legend/data labels or other chart elements.}

--- a/man/CombinedScatter.Rd
+++ b/man/CombinedScatter.Rd
@@ -85,6 +85,7 @@ CombinedScatter(
   legend.title.font.color = global.font.color,
   legend.title.font.family = global.font.family,
   legend.title.font.size = 12,
+  legend.bubble.title = "",
   legend.bubble.font.color = global.font.color,
   legend.bubble.font.family = global.font.family,
   legend.bubble.font.size = 10,
@@ -351,6 +352,8 @@ Values range from -0.5 (left) to 1.5 (right).}
 \item{legend.title.font.family}{Font family of the legend (and color scale bar) title}
 
 \item{legend.title.font.size}{Font size of the legend (and color scale bar) title}
+
+\item{legend.bubble.title}{Title to show above the bubble legend}
 
 \item{legend.bubble.font.color}{Font color of the bubble legend}
 


### PR DESCRIPTION
Added defaults for legend.title and legend.bubble.title. Legend.bubble.title used to be automatically set to scatter.sizes.name but for consistency with the others, its nicer to have the title as a separate parameter