### PR TITLE
FS2-2756: Fix background color bug

### DIFF
--- a/R/combinedscatterplot.R
+++ b/R/combinedscatterplot.R
@@ -537,7 +537,6 @@ CombinedScatter <- function(x = NULL,
         point.border.width = annotations$point.border.width[not.na],
         labels.logo.scale = logo.size,
         background.color = background.fill.color,
-        plot.background.color = charting.area.fill.color,
         bubble.sizes.as.diameter = scatter.sizes.as.diameter,
         debug.mode = grepl("DEBUG_MODE_ON", title))
 


### PR DESCRIPTION
Fixes a bug when the background color is translucent and the plot area ends up being darker as there is a double up of the background color. By not specifying `plot.background.color`, the default of 'transparent' is used.