### PR TITLE
Untracked: fix strange behaviour of duplicates and NAs in rownames

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipStandardCharts
 Type: Package
 Title: Standard R interactive charts
-Version: 1.31.4
+Version: 1.31.5
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other charting packages. The goal is to provide a

--- a/R/chartutils.R
+++ b/R/chartutils.R
@@ -172,14 +172,19 @@ checkMatrixNames <- function(x, assign.col.names = TRUE)
         rownames(new.x) <- 1:NROW(new.x)
     if (is.null(colnames(new.x)) && assign.col.names)
         colnames(new.x) <- sprintf("Series %d", 1:NCOL(new.x))
-    ind.dup <- which(duplicated(rownames(new.x)))
+    ind.na <- which(is.na(rownames(new.x)))
+    if (length(ind.na) > 0)
+        rownames(new.x)[ind.na] <- "NA"
+    row.names <- trimws(rownames(new.x))
+    ind.dup <- which(duplicated(row.names))
     if (length(ind.dup) > 0)
     {
         warning("Row names of the input table are not unique: ",
-                paste(unique(rownames(new.x)[ind.dup]), collapse = ", "), " at rows ",
+                paste(unique(row.names[ind.dup]), collapse = ", "), " at rows ",
                 paste(ind.dup, collapse = ", "))
         # Non-space suffix is needed to stop plotly merging the duplicated rows
-        rownames(new.x) <- MakeUniqueNames(rownames(new.x), suffix = "&nbsp;")
+        # We use the html entity for 0-length space to keep it centered
+        rownames(new.x) <- MakeUniqueNames(row.names, suffix = "&#8203;")
     }
     attr(new.x, "sorted.rows") <- attr(x, "sorted.rows")
     return(new.x)
@@ -925,6 +930,9 @@ setMarginsForAxis <- function(margins, labels, axis)
     lab.len <- 0
     lab.nline <- 0
     lab.nchar <- 1
+
+    # remove space added to de-dup labels
+    labels <- gsub("&#8203;", "", labels, fixed = TRUE)
 
     lab.nchar <- max(c(0, nchar(unlist(strsplit(split="<br>", as.character(labels))))), na.rm = TRUE)
     font.asp <- fontAspectRatio(axis$tickfont$family)

--- a/tests/testthat/test-checkmatrixnames.R
+++ b/tests/testthat/test-checkmatrixnames.R
@@ -222,4 +222,21 @@ test_that("check colnames for cell statistics",
         "9/3/2012-9/16/2012", "9/17/2012-9/30/2012"), "%")))
 })
 
+test_that("Duplicates and NAs",
+{
+    xx <- 1:15
+    names(xx) <- rep(LETTERS[1:3], 5)
+    expect_warning(deduped <- checkMatrixNames(xx))
+    expect_equal(rownames(deduped), c("A", "B", "C", "A&#8203;", "B&#8203;", "C&#8203;",
+        "A&#8203;&#8203;", "B&#8203;&#8203;", "C&#8203;&#8203;",
+        "A&#8203;&#8203;&#8203;", "B&#8203;&#8203;&#8203;", "C&#8203;&#8203;&#8203;",
+        "A&#8203;&#8203;&#8203;&#8203;", "B&#8203;&#8203;&#8203;&#8203;",
+        "C&#8203;&#8203;&#8203;&#8203;"
+    ))
+
+    xx <- 1:3
+    names(xx) <- c('A', NA, 'B')
+    expect_equal(rownames(checkMatrixNames(xx)), c("A", "NA", "B"))
+})
+
 


### PR DESCRIPTION
This PR fixes 
1) duplicated rownames becoming uncentered, raised in https://displayr.slack.com/archives/C013HGKCK9V/p1723727828941759; and
2) NA rownames resulting in bars disappearing from bar/column charts 