### PR TITLE
FS2-2826: Fix when tick max num is specified with a bound

### DIFF
--- a/R/combinedscatterplot.R
+++ b/R/combinedscatterplot.R
@@ -917,7 +917,7 @@ getAxisBoundsUnitsMajor <- function(tick.distance, tick.maxnum, bounds.maximum,
             tmp.min <- if (!is.null(bounds.minimum) && bounds.minimum != "") as.numeric(AsDateTime(bounds.minimum)) else NULL
 
             # Deal with reversed axes
-            if (!is.null(tmp.max) && !is.null(tmp.max) && tmp.max < tmp.min) {
+            if (!is.null(tmp.max) && !is.null(tmp.min) && tmp.max < tmp.min) {
                 tmp.1 <- tmp.min
                 tmp.2 <- tmp.max
                 tmp.min <- tmp.2


### PR DESCRIPTION
Sorry yet another fix. I found this one while going through the area chart diffs. This edge case bug only occurs when tick max num is specified for dates and the max bound is specified but not the min bound.