### PR TITLE
RS-17399: Fix pie chart labels for exporting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipStandardCharts
 Type: Package
 Title: Standard R interactive charts
-Version: 1.31.7
+Version: 1.31.8
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other charting packages. The goal is to provide a

--- a/R/annotdata.R
+++ b/R/annotdata.R
@@ -725,6 +725,9 @@ recolorForPPT <- function(pt, annotation)
 
 # From https://stackoverflow.com/questions/5060076/convert-html-character-entity-encoding-in-r
 unescape_html <- function(str){
+  # html entities are at least 4 characters long
+  if (sum(nchar(str)) < 4)
+      return(str)
   xml2::xml_text(xml2::read_html(paste0("<x>", str, "</x>")))
 }
 

--- a/R/barchart.R
+++ b/R/barchart.R
@@ -461,9 +461,9 @@ Bar <- function(x,
                     chart.labels$SeriesLabels[[i]]$ShowValue <- FALSE
                     pt.segs <- lapply((1:nrow(chart.matrix)),
                         function(ii) list(Index = ii-1, Segments = c(
-                            if (nzchar(data.label.prefix[ii,i])) list(list(Text = data.label.prefix[ii,i])) else NULL,
+                            if (nzchar(data.label.prefix[ii,i])) list(list(Text = unescape_html(data.label.prefix[ii,i]))) else NULL,
                             list(list(Field="Value")),
-                            if (nzchar(tmp.suffix[ii])) list(list(Text = tmp.suffix[ii])) else NULL)))
+                            if (nzchar(tmp.suffix[ii])) list(list(Text = unescape_html(tmp.suffix[ii]))) else NULL)))
 
                     if (multi.color.labels)
                     {

--- a/R/columnchart.R
+++ b/R/columnchart.R
@@ -955,9 +955,9 @@ Column <- function(x,
                 pt <- list(Index = ii-1)
                 if (data.label.show[ii,i])
                     pt$Segments <-  c(
-                    if (nzchar(data.label.prefix[ii,i])) list(list(Text = data.label.prefix[ii,i])) else NULL,
+                    if (nzchar(data.label.prefix[ii,i])) list(list(Text = unescape_html(data.label.prefix[ii,i]))) else NULL,
                     list(list(Field="Value")),
-                    if (nzchar(tmp.suffix[ii])) list(list(Text = tmp.suffix[ii])) else NULL)
+                    if (nzchar(tmp.suffix[ii])) list(list(Text = unescape_html(tmp.suffix[ii]))) else NULL)
                 else
                     pt$ShowValue <- FALSE
                 return(pt)

--- a/R/linechart.R
+++ b/R/linechart.R
@@ -470,9 +470,9 @@ Line <-   function(x,
                 chart.labels$SeriesLabels[[i]]$ShowValue <- FALSE
                 pt.segs <- lapply((1:nrow(chart.matrix)),
                     function(ii) return(list(Index = ii-1, Segments = c(
-                        if (nzchar(dlab.prefix[ii,i])) list(list(Text = dlab.prefix[ii,i])) else NULL,
+                        if (nzchar(dlab.prefix[ii,i])) list(list(Text = unescape_html(dlab.prefix[ii,i]))) else NULL,
                         list(list(Field="Value")),
-                        if (nzchar(dlab.suffix[ii,i])) list(list(Text = dlab.suffix[ii,i])) else NULL))))
+                        if (nzchar(dlab.suffix[ii,i])) list(list(Text = unescape_html(dlab.suffix[ii,i]))) else NULL))))
                 for (ii in setdiff(1:nrow(chart.matrix), ind.show))
                     pt.segs[[ii]]$Segments <- NULL
             }

--- a/R/piechart.R
+++ b/R/piechart.R
@@ -252,5 +252,19 @@ Pie <- function(x,
         attr(result, "ChartType") <- if (type == "Pie") "Pie" else "Doughnut"
     else
         attr(result, "ChartType") <- "Sunburst"
+
+    attr(result, "ChartLabels") <- list(SeriesLabels=list(list(ShowValue = TRUE, Separator = ": ")))
+    if (nzchar(data.label.prefix) || nzchar(data.label.suffix))
+    {
+        tmp.suffix <- if (percentFromD3(data.label.format)) sub("%", "", data.label.suffix)
+                      else                                               data.label.suffix
+        pt.segs <- lapply((1:NROW(x)),
+            function(ii) list(Index = ii-1, Segments = c(
+                list(list(Field = "CategoryName")),
+                list(list(Text = paste0(": ", unescape_html(data.label.prefix)))),
+                list(list(Field = "Value")),
+                if (nzchar(tmp.suffix)) list(list(Text = unescape_html(tmp.suffix))) else NULL)))
+        attr(result, "ChartLabels")$SeriesLabels[[1]]$CustomPoints <- pt.segs
+    }
     result
 }

--- a/R/radarchart.R
+++ b/R/radarchart.R
@@ -388,9 +388,9 @@ Radar <- function(x,
                 pt <- list(Index = ii-1)
                 if (data.label.show[ii,ggi])
                     pt$Segments <-  c(
-                    if (nzchar(data.label.prefix[ii,ggi])) list(list(Text = data.label.prefix[ii,ggi])) else NULL,
+                    if (nzchar(data.label.prefix[ii,ggi])) list(list(Text = unescape_html(data.label.prefix[ii,ggi]))) else NULL,
                     list(list(Field="Value")),
-                    if (nzchar(data.label.suffix[ii,ggi])) list(list(Text = data.label.suffix[ii,ggi])) else NULL)
+                    if (nzchar(data.label.suffix[ii,ggi])) list(list(Text = unescape_html(data.label.suffix[ii,ggi]))) else NULL)
                 return(pt)
             }
         )

--- a/R/stackedcolumnannot.R
+++ b/R/stackedcolumnannot.R
@@ -607,9 +607,9 @@ StackedColumnWithStatisticalSignificance <- function(x,
                 pt <- list(Index = ii-1)
                 if (data.label.show[ii,i])
                     pt$Segments <-  c(
-                    if (nzchar(data.label.prefix[ii,i])) list(list(Text = data.label.prefix[ii,i])) else NULL,
+                    if (nzchar(data.label.prefix[ii,i])) list(list(Text = unescape_html(data.label.prefix[ii,i]))) else NULL,
                     list(list(Field="Value")),
-                    if (nzchar(tmp.suffix[ii])) list(list(Text = tmp.suffix[ii])) else NULL)
+                    if (nzchar(tmp.suffix[ii])) list(list(Text = unescape_html(tmp.suffix[ii]))) else NULL)
                 else
                     pt$ShowValue <- FALSE
                 return(pt)

--- a/tests/testthat/test-chartlabels.R
+++ b/tests/testthat/test-chartlabels.R
@@ -70,6 +70,19 @@ for (charting.func in c("Column", "Bar", "Line", "Radar"))
         }
     })
 
+    test_that("Pie chart data labels",
+    {
+        pp <- Pie(data.with.stats[-10,1,])
+        expect_equal(attr(pp, "ChartLabels"),
+            list(SeriesLabels = list(list(ShowValue = TRUE, Separator = ": "))))
+
+        pp <- Donut(data.with.stats[-10,1,], data.label.prefix = "&#8364;")
+        expect_equal(length(attr(pp, "ChartLabels")$SeriesLabels[[1]]$CustomPoints), 9)
+        expect_equal(attr(pp, "ChartLabels")$SeriesLabels[[1]]$CustomPoints[[9]],
+            list(Index = 8, Segments = list(list(Field = "CategoryName"),
+            list(Text = ": €"), list(Field = "Value"))))
+    })
+
     test_that(paste(charting.func, "ChartLabels with data label annotations"),
     {
         # Some simple cases with annotations


### PR DESCRIPTION
Currently, exported pie charts only show category names instead of the category names with values shown in Displayr. Here we explicitly specify the structure of the pie chart data labels so it matches what is shown in Displayr.