### PR TITLE
RS-17399: Fix exporting of customized pie chart labels

### DIFF
--- a/R/piechart.R
+++ b/R/piechart.R
@@ -253,18 +253,21 @@ Pie <- function(x,
     else
         attr(result, "ChartType") <- "Sunburst"
 
-    attr(result, "ChartLabels") <- list(SeriesLabels=list(list(ShowValue = TRUE, Separator = ": ")))
+    attr(result, "ChartLabels") <- list(SeriesLabels = list(list(ShowValue = TRUE, Separator = ": ")))
     if (nzchar(data.label.prefix) || nzchar(data.label.suffix))
     {
+        # If data labels need to be customized, then each data point should be considered it own series
+        # https://github.com/Displayr/q/blob/e0bc6b1e9eb55b5e9f63cd5e28ac6a91023462a8/QLib/ImportExport/Office/PowerpointXML/PptChartInfo.cs#L179
         tmp.suffix <- if (percentFromD3(data.label.format)) sub("%", "", data.label.suffix)
                       else                                               data.label.suffix
-        pt.segs <- lapply((1:NROW(x)),
-            function(ii) list(Index = ii-1, Segments = c(
-                list(list(Field = "CategoryName")),
-                list(list(Text = paste0(": ", unescape_html(data.label.prefix)))),
-                list(list(Field = "Value")),
-                if (nzchar(tmp.suffix)) list(list(Text = unescape_html(tmp.suffix))) else NULL)))
-        attr(result, "ChartLabels")$SeriesLabels[[1]]$CustomPoints <- pt.segs
+        series.labels <- list()
+        for (i in 1:NROW(x))
+            series.labels[[i]] <- list(CustomPoints = list(Index = 0, Segments = c(
+            list(list(Field = "CategoryName")),
+            list(list(Text = paste0(": ", unescape_html(data.label.prefix)))),
+            list(list(Field = "Value")),
+            if (nzchar(tmp.suffix)) list(list(Text = unescape_html(tmp.suffix))) else NULL)))
+        attr(result, "ChartLabels")$SeriesLabels <- series.labels
     }
     result
 }

--- a/R/piechart.R
+++ b/R/piechart.R
@@ -262,11 +262,13 @@ Pie <- function(x,
                       else                                               data.label.suffix
         series.labels <- list()
         for (i in 1:NROW(x))
+        {
             series.labels[[i]] <- list(CustomPoints = list(list(Index = 0, Segments = c(
-            list(list(Field = "CategoryName")),
-            list(list(Text = paste0(": ", unescape_html(data.label.prefix)))),
-            list(list(Field = "Value")),
-            if (nzchar(tmp.suffix)) list(list(Text = unescape_html(tmp.suffix))) else NULL))))
+                list(list(Field = "CategoryName")),
+                list(list(Text = paste0(": ", unescape_html(data.label.prefix)))),
+                list(list(Field = "Value")),
+                if (nzchar(tmp.suffix)) list(list(Text = unescape_html(tmp.suffix))) else NULL))))
+        }
         attr(result, "ChartLabels")$SeriesLabels <- series.labels
     }
     result

--- a/R/piechart.R
+++ b/R/piechart.R
@@ -262,11 +262,11 @@ Pie <- function(x,
                       else                                               data.label.suffix
         series.labels <- list()
         for (i in 1:NROW(x))
-            series.labels[[i]] <- list(CustomPoints = list(Index = 0, Segments = c(
+            series.labels[[i]] <- list(CustomPoints = list(list(Index = 0, Segments = c(
             list(list(Field = "CategoryName")),
             list(list(Text = paste0(": ", unescape_html(data.label.prefix)))),
             list(list(Field = "Value")),
-            if (nzchar(tmp.suffix)) list(list(Text = unescape_html(tmp.suffix))) else NULL)))
+            if (nzchar(tmp.suffix)) list(list(Text = unescape_html(tmp.suffix))) else NULL))))
         attr(result, "ChartLabels")$SeriesLabels <- series.labels
     }
     result

--- a/tests/testthat/test-chartlabels.R
+++ b/tests/testthat/test-chartlabels.R
@@ -135,7 +135,7 @@ test_that("Pie chart data labels",
 
     pp <- Donut(data.with.stats[-10,1,], data.label.prefix = "&#8364;")
     expect_equal(length(attr(pp, "ChartLabels")$SeriesLabels), 9)
-    expect_equal(attr(pp, "ChartLabels")$SeriesLabels[[9]]$CustomPoints,
+    expect_equal(attr(pp, "ChartLabels")$SeriesLabels[[9]]$CustomPoints[[1]],
         list(Index = 0, Segments = list(list(Field = "CategoryName"),
         list(Text = ": €"), list(Field = "Value"))))
 })

--- a/tests/testthat/test-chartlabels.R
+++ b/tests/testthat/test-chartlabels.R
@@ -70,19 +70,6 @@ for (charting.func in c("Column", "Bar", "Line", "Radar"))
         }
     })
 
-    test_that("Pie chart data labels",
-    {
-        pp <- Pie(data.with.stats[-10,1,])
-        expect_equal(attr(pp, "ChartLabels"),
-            list(SeriesLabels = list(list(ShowValue = TRUE, Separator = ": "))))
-
-        pp <- Donut(data.with.stats[-10,1,], data.label.prefix = "&#8364;")
-        expect_equal(length(attr(pp, "ChartLabels")$SeriesLabels[[1]]$CustomPoints), 9)
-        expect_equal(attr(pp, "ChartLabels")$SeriesLabels[[1]]$CustomPoints[[9]],
-            list(Index = 8, Segments = list(list(Field = "CategoryName"),
-            list(Text = ": €"), list(Field = "Value"))))
-    })
-
     test_that(paste(charting.func, "ChartLabels with data label annotations"),
     {
         # Some simple cases with annotations
@@ -139,6 +126,19 @@ for (charting.func in c("Column", "Bar", "Line", "Radar"))
             list(color = "#FF0000"))
     })
 }
+
+test_that("Pie chart data labels",
+{
+    pp <- Pie(data.with.stats[-10,1,])
+    expect_equal(attr(pp, "ChartLabels"),
+        list(SeriesLabels = list(list(ShowValue = TRUE, Separator = ": "))))
+
+    pp <- Donut(data.with.stats[-10,1,], data.label.prefix = "&#8364;")
+    expect_equal(length(attr(pp, "ChartLabels")$SeriesLabels), 9)
+    expect_equal(attr(pp, "ChartLabels")$SeriesLabels[[9]]$CustomPoints,
+        list(Index = 0, Segments = list(list(Field = "CategoryName"),
+        list(Text = ": €"), list(Field = "Value"))))
+})
 
 test_that("Multi color labels", {
     xx <- c(A = 1, B = 2, C = 3)


### PR DESCRIPTION
Without this fix, custom prefix/suffix is only appended to the first label in the pie chart. I originally thought this was a bug in Displayr, but found a comment indicating pie chart data labels are handled differently to bar charts.