### PR TITLE
RS-18125: Fix handling of empty color categories in combined scatter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipStandardCharts
 Type: Package
 Title: Standard R interactive charts
-Version: 1.32.3
+Version: 1.32.4
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other charting packages. The goal is to provide a

--- a/R/combinedscatterplot.R
+++ b/R/combinedscatterplot.R
@@ -855,11 +855,14 @@ getColors <- function(scatter.groups, scatter.colors, colors, n, not.na,
         legend.show <- FALSE # don't need to worry about order of groups
         colors <- StripAlphaChannel(colors, "Alpha values in selected colors were not used in the numeric color scale. Adjust 'opacity' for transparent points instead")
     }
+
     # Reorder data to make sure legend is ordered correctly
     if (!is.null(scatter.colors) && scatter.colors.as.categorical)
     {
-        groups.ord <- order(suppressWarnings(AsNumeric(scatter.colors[not.na], binary = FALSE)))
+        groups <- suppressWarnings(AsNumeric(scatter.colors, binary = FALSE))
+        groups.ord <- order(groups[not.na])
         not.na <- not.na[groups.ord]
+        colors <- colors[unique(groups[not.na])]
     }
 
     list(colors = colors, scatter.colors = scatter.colors,

--- a/tests/testthat/test-combinedscatterplot.R
+++ b/tests/testthat/test-combinedscatterplot.R
@@ -582,3 +582,29 @@ test_that("quadrants",
                                    x.midpoint.input = c(2,3), y.midpoint.input = 12),
                    "The input for the x midpoint has multiple elements")
 })
+
+test_that("Missing values and named colors",
+{
+    # Scatterplot doesn't actually use names, colors have already been ordered correctly
+    # but functions in flipChartBasics don't know where missing values are
+    named.colors <- c(`Coca-Cola` = "#FF0000",
+                      `Diet Coke` = "#FFC000", `Coke Zero` = "#FFFF00", Pepsi = "#92D050",
+                      `Diet Pepsi` = "#00B050", `Pepsi Max` = "#0070C0", `Unnamed values` = "#CCCCCC")
+    data.missing <- structure(list(
+            X = c("95", "96", NA, "100", "80.5", "91.75"),
+            Y = c("95", "96", NA, "100", "82.75", "91"),
+            Size = c("1", "1", "1", "1", "1", "1"),
+            Colors = c("Coca-Cola", "Diet Coke", "Coke Zero", "Pepsi", "Diet Pepsi", "Pepsi Max")),
+            row.names = c("Coca-Cola", "Diet Coke", "Coke Zero", "Pepsi", "Diet Pepsi", "Pepsi Max"),
+            assigned.rownames = TRUE,
+            scatter.variable.indices = c(x = 1, y = 2, sizes = 3, colors = 4, groups = 4),
+            class = "data.frame")
+
+    # Note these looks the same as if Scatter() was called instead
+    expect_warning(CombinedScatter(data.missing, colors = named.colors), "missing values")
+
+    CombinedScatter(x = 1:5, y = 1:5, scatter.colors.name = "Groups of different sizes",
+                    colors = c(f="red", e="orange", d="yellow", c="green", b="blue", a="purple"),
+                    scatter.colors = factor(letters[c(1,1,3,5,3)], levels = letters[6:1]))
+
+})


### PR DESCRIPTION
Previously, when `scatter.colors` is categorical, the color palette was not updated to remove empty color groups. This can cause problems when there are missing values in the data or if there are factor levels with no observations. This fix means that `CombinedScatter` behaves in the same way as `Scatter`