### PR TITLE
RS-18125: Explicitly convert numeric scatter.colors to levels

### DIFF
--- a/R/combinedscatterplot.R
+++ b/R/combinedscatterplot.R
@@ -859,16 +859,12 @@ getColors <- function(scatter.groups, scatter.colors, colors, n, not.na,
     # Reorder data to make sure legend is ordered correctly
     if (!is.null(scatter.colors) && scatter.colors.as.categorical)
     {
-        groups.is.numeric <- is.numeric(scatter.colors)
-        groups <- suppressWarnings(AsNumeric(scatter.colors, binary = FALSE))
+        groups <- if (is.numeric(scatter.colors)) as.numeric(factor(scatter.colors))
+                  else suppressWarnings(AsNumeric(scatter.colors, binary = FALSE))
         groups.ord <- order(groups[not.na])
         not.na <- not.na[groups.ord]
-       
-        # Remove colors in empty categories
-        if (!groups.is.numeric)
-            colors <- colors[unique(groups[not.na])]
+        colors <- colors[unique(groups[not.na])]
     }
-
     list(colors = colors, scatter.colors = scatter.colors,
          legend.show = legend.show, not.na = not.na)
 }

--- a/R/combinedscatterplot.R
+++ b/R/combinedscatterplot.R
@@ -859,10 +859,14 @@ getColors <- function(scatter.groups, scatter.colors, colors, n, not.na,
     # Reorder data to make sure legend is ordered correctly
     if (!is.null(scatter.colors) && scatter.colors.as.categorical)
     {
+        groups.is.numeric <- is.numeric(scatter.colors)
         groups <- suppressWarnings(AsNumeric(scatter.colors, binary = FALSE))
         groups.ord <- order(groups[not.na])
         not.na <- not.na[groups.ord]
-        colors <- colors[unique(groups[not.na])]
+       
+        # Remove colors in empty categories
+        if (!groups.is.numeric)
+            colors <- colors[unique(groups[not.na])]
     }
 
     list(colors = colors, scatter.colors = scatter.colors,


### PR DESCRIPTION
This fixes the previous commit which was using numeric values (including negatives and floating points) to access the color vector.