### PR TITLE
RS-16397: Suppress uninformative warning in histogram

### DIFF
--- a/R/distribution.R
+++ b/R/distribution.R
@@ -393,7 +393,7 @@ Distribution <-   function(x,
     rng <- x.sorted[c(1, length(x.sorted))]
     if (density.type == "Histogram")
     {
-        bin.min.size <- min(diff(x.sorted))
+        bin.min.size <- suppressWarnings(min(diff(x.sorted)))
         if (!is.finite(bin.min.size))
             bin.min.size <- 1
         if (bin.min.size < sqrt(.Machine$double.eps))

--- a/tests/testthat/test-histogram.R
+++ b/tests/testthat/test-histogram.R
@@ -105,5 +105,5 @@ test_that("Summary table input",
         Missing = 0L, EffectiveSampleSize = 250L, EffectiveSampleSizeProportion = 100,
         FilteredProportion = 0), questiontypes = "Number", footerhtml = "toocheap SUMMARY&lt;br /&gt;sample size = 250; 95% confidence level",
         name = "toocheap", questions = c("toocheap", "SUMMARY"), assigned.rownames = TRUE)
-    expect_error(Histogram(tb), NA)
+    expect_silent(Histogram(tb))
 })


### PR DESCRIPTION
The warning message "no non-missing arguments to min" is not helpful and a bit distracting. The chart should now render without issues so there is enough visual feedback for the user to figure out what to do.