### PR TITLE
RS-19907: Fix default axis bounds for all-negative values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipStandardCharts
 Type: Package
 Title: Standard R interactive charts
-Version: 1.32.7
+Version: 1.32.8
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other charting packages. The goal is to provide a

--- a/R/barchart.R
+++ b/R/barchart.R
@@ -296,7 +296,7 @@ Bar <- function(x,
     tmp.label <- sprintf(paste0("%s%.", data.label.decimals, "f%s"),
                 data.label.prefix, max(chart.matrix), data.label.suffix)
     xtick <- setTicks(x.range$min, x.range$max, x.tick.distance, x.data.reversed, type = type,
-                  data = if (any(data.label.show) && !is.stacked && !pyramid && is.null(x.range$max)) chart.matrix else NULL,
+                  data = if (any(data.label.show) && !is.stacked && !pyramid && (is.null(x.range$max) || is.null(x.range$min))) chart.matrix else NULL,
                   labels = tmp.label, label.font.size = data.label.font.size)
     ytick <- setTicks(y.range$min, y.range$max, y.tick.distance, !y.data.reversed, is.bar = TRUE)
 

--- a/R/chartutils.R
+++ b/R/chartutils.R
@@ -1182,6 +1182,9 @@ setValRange <- function(min, max, values, show.zero = FALSE, use.defaults = TRUE
         min <- charToNumeric(min)
         max <- charToNumeric(max)
     }
+    # When values is only a single value don't use value to determine range
+    if (length(values) == 1)
+        return(list(min = min, max = max))
 
     if  (length(min) == 0 || is.na(min))
         min <- min(unlist(values), if (show.zero) 0 else NULL, na.rm = TRUE)
@@ -1222,14 +1225,10 @@ setTicks <- function(minimum, maximum, distance, reversed = FALSE,
     if (!is.null(data))
     {
         is.bar <- grepl("Bar", type) && !grepl("Stacked", type)
-        if (is.null(minimum))
-            minimum <- min(data, na.rm = TRUE)
-        if (is.null(maximum))
-            maximum <- max(data, na.rm = TRUE)
-        if (all(data > 0, na.rm = TRUE))
-            minimum <- 0
-        else if (all(data < 0, na.rm = TRUE))
-            maximum <- 0
+        dat_min <- min(0, data, na.rm = TRUE)
+        dat_max <- max(data, na.rm = TRUE)
+        if (dat_min == dat_max)
+            dat_max <- 0
 
         # Add horizontal space for data labels in bar charts
         pad <- 0
@@ -1237,12 +1236,16 @@ setTicks <- function(minimum, maximum, distance, reversed = FALSE,
         if (!is.null(labels) && is.bar)
         {
             lab.len <- max(nchar(as.character(unlist(labels))))
-            pad <- (maximum - minimum) * (lab.len+2) * label.font.size / 200
+            pad <- (dat_max - dat_min) * (lab.len+2) * label.font.size / 200
         }
-        if (!is.bar || minimum < 0)
-            minimum <- minimum - pad
-        if (maximum > 0)
-            maximum <- maximum + pad
+        if (!is.bar || dat_min < 0)
+            dat_min <- dat_min - pad
+        if (dat_max > 0)
+            dat_max <- dat_max + pad
+        if (is.null(minimum))
+            minimum <- dat_min
+        if (is.null(maximum))
+            maximum <- dat_max
     }
 
     if (!is.null(minimum) && !is.null(maximum))

--- a/R/chartutils.R
+++ b/R/chartutils.R
@@ -1182,7 +1182,7 @@ setValRange <- function(min, max, values, show.zero = FALSE, use.defaults = TRUE
         min <- charToNumeric(min)
         max <- charToNumeric(max)
     }
-    # When values is only a single value don't use value to determine range
+    # When there is only a single value don't use it to determine range
     if (length(values) == 1)
         return(list(min = min, max = max))
 

--- a/R/chartutils.R
+++ b/R/chartutils.R
@@ -1183,7 +1183,7 @@ setValRange <- function(min, max, values, show.zero = FALSE, use.defaults = TRUE
         max <- charToNumeric(max)
     }
     # When there is only a single value don't use it to determine range
-    if (length(values) == 1)
+    if (length(unique(values)) == 1)
         return(list(min = min, max = max))
 
     if  (length(min) == 0 || is.na(min))
@@ -1225,10 +1225,10 @@ setTicks <- function(minimum, maximum, distance, reversed = FALSE,
     if (!is.null(data))
     {
         is.bar <- grepl("Bar", type) && !grepl("Stacked", type)
-        dat_min <- min(0, data, na.rm = TRUE)
-        dat_max <- max(data, na.rm = TRUE)
-        if (dat_min == dat_max)
-            dat_max <- 0
+        dat.min <- min(0, data, na.rm = TRUE)
+        dat.max <- max(data, na.rm = TRUE)
+        if (dat.min == dat.max)
+            dat.max <- 0
 
         # Add horizontal space for data labels in bar charts
         pad <- 0
@@ -1236,16 +1236,16 @@ setTicks <- function(minimum, maximum, distance, reversed = FALSE,
         if (!is.null(labels) && is.bar)
         {
             lab.len <- max(nchar(as.character(unlist(labels))))
-            pad <- (dat_max - dat_min) * (lab.len+2) * label.font.size / 200
+            pad <- (dat.max - dat.min) * (lab.len+2) * label.font.size / 200
         }
-        if (!is.bar || dat_min < 0)
-            dat_min <- dat_min - pad
-        if (dat_max > 0)
-            dat_max <- dat_max + pad
+        if (!is.bar || dat.min < 0)
+            dat.min <- dat.min - pad
+        if (dat.max > 0)
+            dat.max <- dat.max + pad
         if (is.null(minimum))
-            minimum <- dat_min
+            minimum <- dat.min
         if (is.null(maximum))
-            maximum <- dat_max
+            maximum <- dat.max
     }
 
     if (!is.null(minimum) && !is.null(maximum))

--- a/R/chartutils.R
+++ b/R/chartutils.R
@@ -1219,7 +1219,7 @@ setTicks <- function(minimum, maximum, distance, reversed = FALSE,
     if (reversed)
         autorange <- "reversed"
 
-    if (!is.null(data) && FALSE)
+    if (!is.null(data))
     {
         is.bar <- grepl("Bar", type) && !grepl("Stacked", type)
         if (is.null(minimum))
@@ -1239,9 +1239,10 @@ setTicks <- function(minimum, maximum, distance, reversed = FALSE,
             lab.len <- max(nchar(as.character(unlist(labels))))
             pad <- (maximum - minimum) * (lab.len+2) * label.font.size / 200
         }
-        if (!is.bar || min(data, na.rm = TRUE) < 0)
+        if (!is.bar || any(data < 0))
             minimum <- minimum - pad
-        maximum <- maximum + pad
+        if (any(data > 0))
+            maximum <- maximum + pad
     }
 
     if (!is.null(minimum) && !is.null(maximum))

--- a/R/chartutils.R
+++ b/R/chartutils.R
@@ -1226,9 +1226,9 @@ setTicks <- function(minimum, maximum, distance, reversed = FALSE,
             minimum <- min(data, na.rm = TRUE)
         if (is.null(maximum))
             maximum <- max(data, na.rm = TRUE)
-        if (all(data > 0))
+        if (all(data > 0, na.rm = TRUE))
             minimum <- 0
-        else if (all(data < 0))
+        else if (all(data < 0, na.rm = TRUE))
             maximum <- 0
 
         # Add horizontal space for data labels in bar charts
@@ -1239,9 +1239,9 @@ setTicks <- function(minimum, maximum, distance, reversed = FALSE,
             lab.len <- max(nchar(as.character(unlist(labels))))
             pad <- (maximum - minimum) * (lab.len+2) * label.font.size / 200
         }
-        if (!is.bar || any(data < 0))
+        if (!is.bar || minimum < 0)
             minimum <- minimum - pad
-        if (any(data > 0))
+        if (maximum > 0)
             maximum <- maximum + pad
     }
 

--- a/R/chartutils.R
+++ b/R/chartutils.R
@@ -1223,9 +1223,13 @@ setTicks <- function(minimum, maximum, distance, reversed = FALSE,
     {
         is.bar <- grepl("Bar", type) && !grepl("Stacked", type)
         if (is.null(minimum))
-            minimum <- min(0, min(data, na.rm = TRUE))
+            minimum <- min(data, na.rm = TRUE)
         if (is.null(maximum))
             maximum <- max(data, na.rm = TRUE)
+        if (all(data > 0))
+            minimum <- 0
+        else if (all(data < 0))
+            maximum <- 0
 
         # Add horizontal space for data labels in bar charts
         pad <- 0

--- a/R/chartutils.R
+++ b/R/chartutils.R
@@ -1219,7 +1219,7 @@ setTicks <- function(minimum, maximum, distance, reversed = FALSE,
     if (reversed)
         autorange <- "reversed"
 
-    if (!is.null(data))
+    if (!is.null(data) && FALSE)
     {
         is.bar <- grepl("Bar", type) && !grepl("Stacked", type)
         if (is.null(minimum))

--- a/tests/testthat/test-axis.R
+++ b/tests/testthat/test-axis.R
@@ -23,3 +23,50 @@ test_that("Conversion of factor with numeric levels to numeric",
     expect_equal(convertAxis(xx, "numeric"), c(7, 5, 4))
 })
 
+test_that("setTicks",
+{
+    ticks <- setTicks(NULL, NULL, NULL)
+    expect_equal(ticks$range, NULL)
+
+    ticks <- setTicks(NULL, 20, NULL, data = 1:5)
+    expect_equal(ticks$range, c(0, 20))
+
+    ticks <- setTicks(NULL, 20, NULL, data = -5:5)
+    expect_equal(ticks$range, c(-5, 20))
+
+    ticks <- setTicks(NULL, NULL, NULL, data = -46, labels = "-46")
+    #expect_equal(ticks$range, c(-46, -46)) # plotly can't deal with 0-length range
+
+    ticks <- setTicks(NULL, NULL, NULL, data = -46, labels = "-46", type = "Bar")
+    #expect_equal(ticks$range, c(-46, -46)) # plotly can't deal with 0-length range
+
+    ticks <- setTicks(NULL, 0, NULL, data = -46, labels = "-46", type = "Bar")
+    #expect_equal(ticks$range, c(-57.5, 11.5)) # this used to be c(-46, 0) with datalabel overlapping rowlabel
+
+    ticks <- setTicks(-50, NULL, NULL, data = -46, labels = "-46")
+    expect_equal(ticks$range, c(-50, -46))
+
+    ticks <- setTicks(NULL, NULL, NULL, data = 46, labels = "46")
+    expect_equal(ticks$range, c(0, 46))
+
+    ticks <- setTicks(NULL, NULL, NULL, data = 46, labels = "46", type = "Bar")
+    expect_equal(ticks$range, c(0, 55.2))
+
+    ticks <- setTicks(40, NULL, NULL, data = 46, labels = "46", type = "Bar")
+    expect_equal(ticks$range, c(40, 55.2))
+
+    neg_data <- -50 + 1:5
+    neg_labels <- sprintf("%.2f", neg_data)
+    ticks <- setTicks(NULL, NULL, NULL, data = neg_data, labels = neg_labels)
+    expect_equal(ticks$range, c(-49, -45))
+
+    ticks <- setTicks(NULL, NULL, NULL, data = neg_data, labels = neg_labels, type = "Bar")
+    expect_equal(ticks$range, c(-50.6, -45))
+
+    pos_and_neg_data <- -5:5
+    pos_and_neg_labels <- sprintf("%.2f", pos_and_neg_data)
+    ticks <- setTicks(NULL, NULL, NULL, data = pos_and_neg_data, labels = pos_and_neg_labels, type = "Bar")
+    expect_equal(ticks$range, c(-8.5, 8.5))
+
+})
+

--- a/tests/testthat/test-axis.R
+++ b/tests/testthat/test-axis.R
@@ -44,7 +44,7 @@ test_that("setTicks",
     expect_equal(ticks$range, c(-57.5, 0))
 
     ticks <- setTicks(-50, NULL, NULL, data = -46, labels = "-46")
-    expect_equal(ticks$range, c(-50, -0))
+    expect_equal(ticks$range, c(-50, 0))
 
     ticks <- setTicks(NULL, NULL, NULL, data = 46, labels = "46")
     expect_equal(ticks$range, c(0, 46))

--- a/tests/testthat/test-axis.R
+++ b/tests/testthat/test-axis.R
@@ -35,16 +35,16 @@ test_that("setTicks",
     expect_equal(ticks$range, c(-5, 20))
 
     ticks <- setTicks(NULL, NULL, NULL, data = -46, labels = "-46")
-    #expect_equal(ticks$range, c(-46, -46)) # plotly can't deal with 0-length range
+    expect_equal(ticks$range, c(-46, 0))
 
     ticks <- setTicks(NULL, NULL, NULL, data = -46, labels = "-46", type = "Bar")
-    #expect_equal(ticks$range, c(-46, -46)) # plotly can't deal with 0-length range
+    expect_equal(ticks$range, c(-57.5, 0))
 
     ticks <- setTicks(NULL, 0, NULL, data = -46, labels = "-46", type = "Bar")
-    #expect_equal(ticks$range, c(-57.5, 11.5)) # this used to be c(-46, 0) with datalabel overlapping rowlabel
+    expect_equal(ticks$range, c(-57.5, 0))
 
     ticks <- setTicks(-50, NULL, NULL, data = -46, labels = "-46")
-    expect_equal(ticks$range, c(-50, -46))
+    expect_equal(ticks$range, c(-50, -0))
 
     ticks <- setTicks(NULL, NULL, NULL, data = 46, labels = "46")
     expect_equal(ticks$range, c(0, 46))

--- a/tests/testthat/test-barpictograph.R
+++ b/tests/testthat/test-barpictograph.R
@@ -19,12 +19,9 @@ test_that("Warnings for invalid parameters",
 
 test_that("Custom image",
 {
-    expect_error(BarPictograph(1:6, custom.image = "https://wiki.q-researchsoftware.com/images/7/78/Democrats_donkey_black.png"), NA)
-    expect_error(BarPictograph(1:6, custom.image = "tps://wiki.q-researchsoftware.com/images/7/78/Democrats_donkey_black.png"),
+    expect_error(BarPictograph(1:6, custom.image = "https://displayrcors.displayr.com/images/apple_grey.svg"), NA)
+    expect_error(BarPictograph(1:6, custom.image = "tps://displayrcors.displayr.com/images/apple_grey.svg"),
                  "Could not retrieve image")
-    expect_error(BarPictograph(1:6, custom.image = "https://wiki.q-researchsoftware.com/images/7/78/Demorats_donkey_black.png"),
-                 "Error (status code 404) retrieving image", fixed = TRUE)
-
 })
 
 

--- a/tests/testthat/test-barpictograph.R
+++ b/tests/testthat/test-barpictograph.R
@@ -19,7 +19,7 @@ test_that("Warnings for invalid parameters",
 
 test_that("Custom image",
 {
-    skip_on_ci()
+    skip()
     expect_error(BarPictograph(1:6, custom.image = "https://wiki.q-researchsoftware.com/images/7/78/Democrats_donkey_black.png"), NA)
     expect_error(BarPictograph(1:6, custom.image = "tps://wiki.q-researchsoftware.com/images/7/78/Democrats_donkey_black.png"),
                  "Could not retrieve image")

--- a/tests/testthat/test-barpictograph.R
+++ b/tests/testthat/test-barpictograph.R
@@ -19,7 +19,7 @@ test_that("Warnings for invalid parameters",
 
 test_that("Custom image",
 {
-    skip()
+    skip_if_offline()
     expect_error(BarPictograph(1:6, custom.image = "https://wiki.q-researchsoftware.com/images/7/78/Democrats_donkey_black.png"), NA)
     expect_error(BarPictograph(1:6, custom.image = "tps://wiki.q-researchsoftware.com/images/7/78/Democrats_donkey_black.png"),
                  "Could not retrieve image")

--- a/tests/testthat/test-barpictograph.R
+++ b/tests/testthat/test-barpictograph.R
@@ -19,9 +19,13 @@ test_that("Warnings for invalid parameters",
 
 test_that("Custom image",
 {
-    expect_error(BarPictograph(1:6, custom.image = "https://displayrcors.displayr.com/images/apple_grey.svg"), NA)
-    expect_error(BarPictograph(1:6, custom.image = "tps://displayrcors.displayr.com/images/apple_grey.svg"),
+    skip_on_ci()
+    expect_error(BarPictograph(1:6, custom.image = "https://wiki.q-researchsoftware.com/images/7/78/Democrats_donkey_black.png"), NA)
+    expect_error(BarPictograph(1:6, custom.image = "tps://wiki.q-researchsoftware.com/images/7/78/Democrats_donkey_black.png"),
                  "Could not retrieve image")
+    expect_error(BarPictograph(1:6, custom.image = "https://wiki.q-researchsoftware.com/images/7/78/Demorats_donkey_black.png"),
+                 "Error (status code 404) retrieving image", fixed = TRUE)
+
 })
 
 


### PR DESCRIPTION
Most of the time, the default axis bounds are automatically determined by plotly, but for bar charts with data labels we manually override plotly defaults because plotly will sometimes not leave enough space on the x-axis for the data labels and truncate the labels instead. 
This PR fixes the axis bounds overrides for the case when all values are negative.