### PR TITLE
RS-20619: Allow zero labels to be shown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipStandardCharts
 Type: Package
 Title: Standard R interactive charts
-Version: 1.32.8
+Version: 1.32.9
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other charting packages. The goal is to provide a

--- a/R/datalabelpositions.R
+++ b/R/datalabelpositions.R
@@ -44,7 +44,6 @@ dataLabelPositions <- function(chart.matrix,
         if (is.null(display.threshold))
             display.threshold <- 0.05
         text[abs(chart.matrix) < largest.bar * display.threshold] <- ""
-        text[chart.matrix == 0] <- ""
 
 
     } else


### PR DESCRIPTION
Turn off arbitrary removal of data labels at zero (although in most cases they will be removed because `data.label.threshold` defaults to 0.05). But in certain cases we may want to show it, e.g. 
<img width="1073" height="707" alt="Screenshot 2025-12-17 111423" src="https://github.com/user-attachments/assets/8160153e-ce18-43b7-ba6d-d5226aff2049" />
