### PR TITLE
Try to keep number of decimals shown unchanged

### DIFF
--- a/R/annotdata.R
+++ b/R/annotdata.R
@@ -376,7 +376,7 @@ addAnnotToDataLabel <- function(data.label.text, annotation, tmp.dat,
         else if (annotation$type == "Custom text")
             new.text <- annotation$custom.symbol
         else if (grepl("Text", annotation$type))
-            new.text <- formatByD3(tmp.dat, annotation$format, annotation$prefix, annotation$suffix)
+            new.text <- formatByD3(tmp.dat, annotation$format, annotation$prefix, annotation$suffix, decimals = "max")
         else if (annotation$type == "Hide")
             new.text <- ""
         if (any(nzchar(new.style)))
@@ -548,13 +548,17 @@ getPointSegmentsForPPT <- function(points, index, annot, dat)
                         Text = setTextForPPT(annot)))
     }
 
+    # Resolve the "max" decimals fallback once over the whole slice so rows
+    # render with a consistent decimal count instead of varying row by row.
+    text.decimals <- if (is.numeric(dat)) maxDecimalsNeeded(dat) else 0
+
     for (i in 1:length(index))
     {
         # Set text only if it depends on the data
         # Note that we use i to select elements of dat because it is assumed that we are only
         # passing the relevant sections of the data (i.e. dat is already subsetted by index)
         if (grepl("^Text", annot$type))
-            tmp.seg[[1]]$Text <- unescape_html(formatByD3(dat[i], annot$format, annot$prefix, annot$suffix))
+            tmp.seg[[1]]$Text <- unescape_html(formatByD3(dat[i], annot$format, annot$prefix, annot$suffix, decimals = text.decimals))
         else if (annot$data == "Column Comparisons" && grepl("Arrow", annot$type))
             tmp.seg[[1]]$Text <- unescape_html(getColCmpArrowHtml(dat[i], NULL, " ", "&#8593;"))
         else if (annot$data == "Column Comparisons" && grepl("Caret", annot$type))

--- a/R/annotdata.R
+++ b/R/annotdata.R
@@ -376,7 +376,7 @@ addAnnotToDataLabel <- function(data.label.text, annotation, tmp.dat,
         else if (annotation$type == "Custom text")
             new.text <- annotation$custom.symbol
         else if (grepl("Text", annotation$type))
-            new.text <- formatByD3(tmp.dat, annotation$format, annotation$prefix, annotation$suffix)
+            new.text <- formatByD3(tmp.dat, annotation$format, annotation$prefix, annotation$suffix, decimals = 0)
         else if (annotation$type == "Hide")
             new.text <- ""
         if (any(nzchar(new.style)))
@@ -554,7 +554,7 @@ getPointSegmentsForPPT <- function(points, index, annot, dat)
         # Note that we use i to select elements of dat because it is assumed that we are only
         # passing the relevant sections of the data (i.e. dat is already subsetted by index)
         if (grepl("^Text", annot$type))
-            tmp.seg[[1]]$Text <- unescape_html(formatByD3(dat[i], annot$format, annot$prefix, annot$suffix))
+            tmp.seg[[1]]$Text <- unescape_html(formatByD3(dat[i], annot$format, annot$prefix, annot$suffix, decimals = 0))
         else if (annot$data == "Column Comparisons" && grepl("Arrow", annot$type))
             tmp.seg[[1]]$Text <- unescape_html(getColCmpArrowHtml(dat[i], NULL, " ", "&#8593;"))
         else if (annot$data == "Column Comparisons" && grepl("Caret", annot$type))

--- a/R/annotdata.R
+++ b/R/annotdata.R
@@ -376,7 +376,7 @@ addAnnotToDataLabel <- function(data.label.text, annotation, tmp.dat,
         else if (annotation$type == "Custom text")
             new.text <- annotation$custom.symbol
         else if (grepl("Text", annotation$type))
-            new.text <- formatByD3(tmp.dat, annotation$format, annotation$prefix, annotation$suffix, decimals = "max")
+            new.text <- formatByD3(tmp.dat, annotation$format, annotation$prefix, annotation$suffix)
         else if (annotation$type == "Hide")
             new.text <- ""
         if (any(nzchar(new.style)))
@@ -548,17 +548,13 @@ getPointSegmentsForPPT <- function(points, index, annot, dat)
                         Text = setTextForPPT(annot)))
     }
 
-    # Resolve the "max" decimals fallback once over the whole slice so rows
-    # render with a consistent decimal count instead of varying row by row.
-    text.decimals <- if (is.numeric(dat)) maxDecimalsNeeded(dat) else 0
-
     for (i in 1:length(index))
     {
         # Set text only if it depends on the data
         # Note that we use i to select elements of dat because it is assumed that we are only
         # passing the relevant sections of the data (i.e. dat is already subsetted by index)
         if (grepl("^Text", annot$type))
-            tmp.seg[[1]]$Text <- unescape_html(formatByD3(dat[i], annot$format, annot$prefix, annot$suffix, decimals = text.decimals))
+            tmp.seg[[1]]$Text <- unescape_html(formatByD3(dat[i], annot$format, annot$prefix, annot$suffix))
         else if (annot$data == "Column Comparisons" && grepl("Arrow", annot$type))
             tmp.seg[[1]]$Text <- unescape_html(getColCmpArrowHtml(dat[i], NULL, " ", "&#8593;"))
         else if (annot$data == "Column Comparisons" && grepl("Caret", annot$type))

--- a/R/chartutils.R
+++ b/R/chartutils.R
@@ -1465,6 +1465,21 @@ decimalsFromD3 <- function(format, default = 0)
     return(SumEmptyHandling(as.numeric(regmatches(format, regexpr("\\d+", format))), remove.missing = FALSE))
 }
 
+# Minimum decimals needed to represent x without truncation, capped at `cap`.
+# Used as the "max" fallback for formatByD3 so integer-valued data renders with
+# no trailing zeros while fractional data keeps enough precision.
+maxDecimalsNeeded <- function(x, cap = 6)
+{
+    x <- x[is.finite(x)]
+    if (length(x) == 0)
+        return(0)
+    tol <- .Machine$double.eps^0.5
+    for (d in 0:cap)
+        if (all(abs(x - round(x, d)) < tol))
+            return(d)
+    cap
+}
+
 #' Whether to format as percentages based on a d3 format string.
 #'
 #' All chart functions should accept d3 formats. This is used by functions
@@ -1485,7 +1500,9 @@ percentFromD3 <- function(format)
 #' @param format D3 formatting string. Accepts percentages, numeric and scientific notation
 #' @param prefix Optional string to prepend to output
 #' @param suffix Optional string to append to output
-#' @param decimals Default number of decimals shown; used if not specified in \code{format}
+#' @param decimals Default number of decimals shown; used if not specified in \code{format}.
+#' Pass the string \code{"max"} to derive the default from the values themselves
+#' (no trailing zeros for integer-valued data; just enough precision otherwise).
 formatByD3 <- function(x, format, prefix = "", suffix = "", percent = FALSE, decimals = 2)
 {
     n <- length(x)
@@ -1496,9 +1513,16 @@ formatByD3 <- function(x, format, prefix = "", suffix = "", percent = FALSE, dec
         format <- vectorize(format, n)
         prefix <- vectorize(prefix, n)
         suffix <- vectorize(suffix, n)
+        # Resolve "max" once against the full vector so all rows render with a
+        # consistent decimal count instead of varying row by row.
+        if (identical(decimals, "max"))
+            decimals <- if (is.numeric(x)) maxDecimalsNeeded(x) else 0
         return(sapply(1:n, function(i)
             formatByD3(x[i], format[i], prefix[i], suffix[i], percent = percent, decimals = decimals)))
     }
+
+    if (identical(decimals, "max"))
+        decimals <- if (is.numeric(x)) maxDecimalsNeeded(x) else 0
 
     x.str <- as.character(x)
     if (format == "Category")

--- a/R/chartutils.R
+++ b/R/chartutils.R
@@ -1465,21 +1465,6 @@ decimalsFromD3 <- function(format, default = 0)
     return(SumEmptyHandling(as.numeric(regmatches(format, regexpr("\\d+", format))), remove.missing = FALSE))
 }
 
-# Minimum decimals needed to represent x without truncation, capped at `cap`.
-# Used as the "max" fallback for formatByD3 so integer-valued data renders with
-# no trailing zeros while fractional data keeps enough precision.
-maxDecimalsNeeded <- function(x, cap = 6)
-{
-    x <- x[is.finite(x)]
-    if (length(x) == 0)
-        return(0)
-    tol <- .Machine$double.eps^0.5
-    for (d in 0:cap)
-        if (all(abs(x - round(x, d)) < tol))
-            return(d)
-    cap
-}
-
 #' Whether to format as percentages based on a d3 format string.
 #'
 #' All chart functions should accept d3 formats. This is used by functions
@@ -1500,9 +1485,7 @@ percentFromD3 <- function(format)
 #' @param format D3 formatting string. Accepts percentages, numeric and scientific notation
 #' @param prefix Optional string to prepend to output
 #' @param suffix Optional string to append to output
-#' @param decimals Default number of decimals shown; used if not specified in \code{format}.
-#' Pass the string \code{"max"} to derive the default from the values themselves
-#' (no trailing zeros for integer-valued data; just enough precision otherwise).
+#' @param decimals Default number of decimals shown; used if not specified in \code{format}
 formatByD3 <- function(x, format, prefix = "", suffix = "", percent = FALSE, decimals = 2)
 {
     n <- length(x)
@@ -1513,16 +1496,9 @@ formatByD3 <- function(x, format, prefix = "", suffix = "", percent = FALSE, dec
         format <- vectorize(format, n)
         prefix <- vectorize(prefix, n)
         suffix <- vectorize(suffix, n)
-        # Resolve "max" once against the full vector so all rows render with a
-        # consistent decimal count instead of varying row by row.
-        if (identical(decimals, "max"))
-            decimals <- if (is.numeric(x)) maxDecimalsNeeded(x) else 0
         return(sapply(1:n, function(i)
             formatByD3(x[i], format[i], prefix[i], suffix[i], percent = percent, decimals = decimals)))
     }
-
-    if (identical(decimals, "max"))
-        decimals <- if (is.numeric(x)) maxDecimalsNeeded(x) else 0
 
     x.str <- as.character(x)
     if (format == "Category")

--- a/R/columnchart.R
+++ b/R/columnchart.R
@@ -1041,7 +1041,7 @@ Column <- function(x,
                 if (curr.annot$data == "Column Comparisons" && grepl("Arrow", curr.annot$type))
                     curr.annot.text <- getColCmpArrowHtml(curr.dat[ind.sel], curr.annot$size, "<br>")
                 else if (curr.annot$type == "Text")
-                    curr.annot.text <- formatByD3(curr.dat[ind.sel], curr.annot$format, curr.annot$prefix, curr.annot$suffix)
+                    curr.annot.text <- formatByD3(curr.dat[ind.sel], curr.annot$format, curr.annot$prefix, curr.annot$suffix, decimals = 0)
                 else if (curr.annot$type == "Arrow - up")
                     curr.annot.text <- "&#8593;"
                 else if (curr.annot$type == "Arrow - down")


### PR DESCRIPTION
The previous change for RS-22196 unintentionally caused changes where extra decimals were shown for numeric data. In this PR we add an adjustment where numeric data with no format string supplied will automatically be round to 0 decimals.

Initially we tried to automatically determine how many decimals were shown, but the function suggested by Claude didn't reproduce the original behaviour (see [8a90ea8](https://github.com/Displayr/flipStandardCharts/pull/126/commits/8a90ea8f8f26726319febf8d16cd5047d64f0f5a)). For example, if you had originally tried to show p-values it would look like this
<img width="915" height="655" alt="image" src="https://github.com/user-attachments/assets/622ca2ef-b215-43fd-a2f9-5c8d2f043212" />

Probably this is not the desired output for anyone so a change to default to 0 decimals seems to be the simplest fix
