### PR TITLE
RS-22530 Resolve annotation font color per-series for export

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,14 @@
 Package: flipStandardCharts
 Type: Package
 Title: Standard R interactive charts
-Version: 1.32.12
+Version: 1.32.13
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other charting packages. The goal is to provide a
     relatively standard API across multiple packages, so that a user can create
     just about any 'standard' chart easily.
 License: GPL-3
-Depends: R (>= 3.5.0)
+Depends: R (>= 4.1.0)
 LazyData: TRUE
 Imports:
     d3vennR,

--- a/R/annotdata.R
+++ b/R/annotdata.R
@@ -318,6 +318,7 @@ extractSelectedAnnot <- function(data, threshold, threstype)
 #' annotation is directly inserted into an svg text element, whereas span is
 #' used with Plotly-drawn labels (Plotly automatically converts it to tspan).
 #' @importFrom verbs Sum
+#' @importFrom flipU ConvertCommaSeparatedStringToVector
 #' @keywords internal
 addAnnotToDataLabel <- function(data.label.text, annotation, tmp.dat,
                                 prepend = FALSE, tspan = FALSE)
@@ -512,6 +513,19 @@ applyAllAnnotationsToDataLabels <- function(data.label.text, annotation.list,
             return(data.label.text)
         annotation.list[[j]]$threshold <- parseThreshold(annotation.list[[j]]$threshold)
         a.tmp <- annotation.list[[j]]
+
+        # Resolve the annotation color to this series' color when multiple colors
+        # have been supplied (e.g. an annotation configured to match each series'
+        # own color arrives as a single comma-joined string of per-series colors).
+        # Both the HTML (addAnnotToDataLabel) and PPT (getPointSegmentsForPPT)
+        # paths below assume a scalar color, so this must happen before either.
+        if (!is.null(a.tmp$color))
+        {
+            color.vec <- ConvertCommaSeparatedStringToVector(a.tmp$color)
+            if (length(color.vec) > 1)
+                a.tmp$color <- color.vec[((series.index - 1) %% length(color.vec)) + 1]
+        }
+
         tmp.dat <- getAnnotData(annot.data, a.tmp$data, series.index)
         ind.sel <- intersect(rows.to.show,
                         extractSelectedAnnot(tmp.dat, a.tmp$threshold, a.tmp$threstype))

--- a/tests/testthat/test-annotationfunctions.R
+++ b/tests/testthat/test-annotationfunctions.R
@@ -167,3 +167,40 @@ test_that("addAnnotToDataLabel",
     }
 })
 
+test_that("RS-22530: annotation font color is resolved per-series",
+{
+    # For a per-series-colored chart, data.label.font.color arrives as a single
+    # comma-joined string (one hex per series). The auto-generated
+    # "Column Comparisons" annotation reuses that string verbatim (flipChart
+    # cchart.R), so each series' exported annotation segment must pick out its
+    # OWN color rather than being styled with the whole comma-joined string.
+    gatherSegColors <- function(pt.segs)
+    {
+        cols <- character(0)
+        for (pt in pt.segs)
+        {
+            if (is.null(pt$Segments)) next
+            for (s in pt$Segments)
+                if (!is.null(s$Font$color)) cols <- c(cols, s$Font$color)
+        }
+        cols
+    }
+    annot <- list(list(type = "Text - after data label", data = "Column Comparisons",
+        threstype = "above threshold", threshold = "", format = "",
+        prefix = "", suffix = "", color = "#FAA634,#a1a1a4,#46166B",
+        size = 10, font.family = "Arial"))
+    dlab <- paste0("d", 1:8)
+    expected <- c("#FAA634", "#a1a1a4", "#46166B")
+    for (s in 1:3)
+    {
+        # Initialise customPoints the same way the chart functions do: one point
+        # per row, each carrying the base data-label Value segment.
+        attr(dlab, "customPoints") <- lapply(1:8,
+            function(ii) list(Index = ii - 1, Segments = list(list(Field = "Value"))))
+        out <- applyAllAnnotationsToDataLabels(dlab, annot, tb.as.char,
+            series.index = s, rows.to.show = 1:8, chart.type = "Column")
+        seg.colors <- gatherSegColors(attr(out, "customPoints"))
+        expect_equal(unique(seg.colors), expected[s])
+    }
+})
+


### PR DESCRIPTION
## Problem

[RS-22530](https://numbers.atlassian.net/browse/RS-22530) (High, escalated for a large USE customer): a Column Comparisons annotation on a Line chart exports to PowerPoint with a font color that doesn't match its data label.

## Root cause

For a per-series-colored chart, `data.label.font.color` arrives as a single comma-joined string (one hex per series, e.g. `"#FAA634,#a1a1a4,#46166B"`). `flipChart`'s `cchart.R` reuses that string verbatim as the auto-generated Column Comparisons annotation `color`. `applyAllAnnotationsToDataLabels` (`R/annotdata.R`) threaded `series.index` through to `getAnnotData` for the annotation *value* but never for the *color*, so `setFontForPPT`/`recolorForPPT` took `annotation$color[1]` — the entire comma-joined string — for every series.

**Why only PowerPoint is affected:** the on-screen chart survives only by accident. The HTML path emits the same string as `style='color:#FAA634,#a1a1a4,#46166B;'`, an invalid CSS color that the browser discards, so the annotation span inherits the correct per-series data-label color. PPT has no such fallback and applies the literal string.

Can also test this on reusdev on https://staff.displayr.com/Dashboard?project_id=-1367343#page=f1d66aa9-c69e-4c79-9379-932765e57664

[RS-22530]: https://numbers.atlassian.net/browse/RS-22530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ