### PR TITLE
RS-22838: Geographic Region Row Names test

### DIFF
--- a/tests/testthat/test-geographicmap.R
+++ b/tests/testthat/test-geographicmap.R
@@ -136,3 +136,28 @@ test_that("DS-3647: Can recognize new counties of Norway",
                        `Troms og Finnmark` = 9))
     expect_silent(GeographicMap(tbl, mapping.package = "leaflet"))
 })
+
+test_that ("GeographicRegionRowNames deprecated wrapper: country", {
+    result <- NULL
+    expect_error(result <- GeographicRegionRowNames("country"), NA)
+    expect_equal(result, CountriesOrContinents("country"))
+    expect_is(result, "character")
+    expect_gt(length(result), 0)
+})
+
+test_that ("GeographicRegionRowNames deprecated wrapper: name", {
+    result <- NULL
+    expect_error(result <- GeographicRegionRowNames("name"), NA)
+    expect_equal(result, CountriesOrContinents("name"))
+    expect_is(result, "character")
+    expect_gt(length(result), 0)
+})
+
+test_that ("GeographicRegionRowNames deprecated wrapper: continent", {
+    result <- NULL
+    expect_error(result <- GeographicRegionRowNames("continent"), NA)
+    expect_equal(result, CountriesOrContinents("continent"))
+    expect_is(result, "character")
+    expect_gt(length(result), 0)
+    expect_equal(result, levels(flipStandardCharts:::map.coordinates.50[["continent"]]))
+})


### PR DESCRIPTION
## Summary
- Added 3 `test_that` scenarios to `test-geographicmap.R` covering the deprecated `GeographicRegionRowNames` wrapper for the `"country"`, `"name"`, and `"continent"` types.
- Each test asserts the wrapper returns a result identical to the underlying `CountriesOrContinents` call, is a non-empty character vector, and raises no error.
- The `"continent"` case additionally pins the result independently against `levels(map.coordinates.50[["continent"]])`, so a regression in either function (not just a change that keeps them consistent with each other) would be caught.

Jira: https://numbers.atlassian.net/browse/RS-22838

## Test plan
- From an R session with the working directory at the package root, run:
  `devtools::test(filter = "geographicmap")`
  or
  `testthat::test_file("tests/testthat/test-geographicmap.R")`
- Confirm all tests pass, including the 3 new `test_that` blocks named "GeographicRegionRowNames deprecated wrapper: country/name/continent".

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
