### PR TITLE
FS2-4532: Fix Standard R tests regressions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipStandardCharts
 Type: Package
 Title: Standard R interactive charts
-Version: 1.32.15
+Version: 1.32.16
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrapper for other charting packages. The goal is to provide a

--- a/R/labeledlinechart.R
+++ b/R/labeledlinechart.R
@@ -356,7 +356,14 @@ labeledLine <- function(x,
         labels.show = TRUE,
         label.auto.placement = TRUE,
         labels.font.family = data.label.font.family,
-        labels.font.color = if (data.label.font.autocolor) NULL else dlab.color[1],
+        # One colour per point, in the same order as the labels: the widget colours each
+        # label individually, so a colour per series is spread across that series' points.
+        # Sized to the charted columns rather than to dlab.color, which is worked out before
+        # an average series adds one and so would leave the arrays a series short.
+        # Automatic colouring still sends nothing, leaving each label to take the colour of
+        # its own point, which is already the series colour.
+        labels.font.color = if (data.label.font.autocolor) NULL
+                            else rep(vectorize(dlab.color, n.col), each = n.row),
         labels.font.size = data.label.font.size,
         line.show = TRUE,
         line.colors = toRGB(colors, alpha = opacity),
@@ -613,10 +620,6 @@ warnUnsupportedByAutoPlacement <- function(args, n.col, n.row)
     # the whole chart is the contract on both routes, so prepareLineSeries reports it for
     # either; naming it here as well would say it twice, and would promise that turning
     # automatic placement off gives the markers a per-series opacity, which it does not.
-    if (!args$data.label.font.autocolor &&
-        length(unique(vectorize(args$data.label.font.color, n.col))) > 1)
-        ignored <- c(ignored, "data.label.font.color")
-
     # These default to another argument, so they can only be judged against it. The
     # widget takes one set of series colors, used for the markers and for automatically
     # colored data labels alike, so markers cannot be colored separately from the lines.

--- a/R/labeledlinechart.R
+++ b/R/labeledlinechart.R
@@ -574,6 +574,11 @@ fitSeriesForCombinedScatter <- function(chart.matrix, x.labels, x.axis.type, fit
 
 # Arguments of Line() that rhtmlCombinedScatter has no equivalent for. Each entry is the
 # value the argument has to hold for the chart to be unaffected; anything else is dropped.
+#
+# A per-series opacity inherited by the markers is deliberately not among them. One marker
+# opacity for the whole chart is the contract on both routes, so prepareLineSeries reports the
+# collapse for either; naming it here as well would say it twice, and would promise that
+# turning automatic placement off gives the markers a per-series opacity, which it does not.
 UNSUPPORTED.BY.AUTO.PLACEMENT <- list(
     x.data.reversed = FALSE,
     y.data.reversed = FALSE,
@@ -616,10 +621,6 @@ warnUnsupportedByAutoPlacement <- function(args, n.col, n.row)
         TRUE
     }, logical(1L))]
 
-    # A per-series opacity inherited by the markers is not listed here. One marker opacity for
-    # the whole chart is the contract on both routes, so prepareLineSeries reports it for
-    # either; naming it here as well would say it twice, and would promise that turning
-    # automatic placement off gives the markers a per-series opacity, which it does not.
     # These default to another argument, so they can only be judged against it. The
     # widget takes one set of series colors, used for the markers and for automatically
     # colored data labels alike, so markers cannot be colored separately from the lines.

--- a/R/scatterchart.R
+++ b/R/scatterchart.R
@@ -502,7 +502,11 @@ Scatter <- function(x = NULL,
     groups <- groups[not.na]
     num.series <- if (scatter.colors.as.numeric) 1 else num.groups
 
-    colors <- vectorize(colors, num.groups)
+    # A numeric colour scale has already turned the palette into one colour per data point
+    # above, so from here `colors` is not a per-series palette and must not be sized to the
+    # series count: there is only one series, and every point would take the first colour.
+    if (!scatter.colors.as.numeric)
+        colors <- vectorize(colors, num.groups)
     if (is.null(fit.line.colors))
         fit.line.colors <- colors
     if (is.null(fit.CI.colors))
@@ -512,7 +516,10 @@ Scatter <- function(x = NULL,
     if (is.null(marker.border.colors))
         marker.border.colors <- colors
     line.colors <- vectorize(line.colors, num.groups)
-    marker.border.colors <- vectorize(marker.border.colors, num.groups)
+    # The numeric trace is given the border colours whole rather than one per series, and
+    # they default to the point colours, so they are left per point for the same reason.
+    if (!scatter.colors.as.numeric)
+        marker.border.colors <- vectorize(marker.border.colors, num.groups)
 
     marker.symbols <- vectorize(marker.symbols, num.groups)
     data.label.font.color <- vectorize(data.label.font.color, num.groups)

--- a/R/scatterchart.R
+++ b/R/scatterchart.R
@@ -516,9 +516,12 @@ Scatter <- function(x = NULL,
     if (is.null(marker.border.colors))
         marker.border.colors <- colors
     line.colors <- vectorize(line.colors, num.groups)
-    # The numeric trace is given the border colours whole rather than one per series, and
-    # they default to the point colours, so they are left per point for the same reason.
-    if (!scatter.colors.as.numeric)
+    # The numeric trace is given the border colours whole rather than one per series, and by
+    # default they are the point colours, so a value that is already one per point is left
+    # alone. A palette the caller supplied is not one per point: it is still sized to the
+    # series count, as the settings around it are, rather than reaching a trace of n points
+    # with fewer than n colours and bordering only the first few.
+    if (!isPerPointSetting(marker.border.colors, num.groups, n))
         marker.border.colors <- vectorize(marker.border.colors, num.groups)
 
     marker.symbols <- vectorize(marker.symbols, num.groups)

--- a/tests/testthat/test-labeledlinechart.R
+++ b/tests/testthat/test-labeledlinechart.R
@@ -649,6 +649,11 @@ test_that("An average series does not shift the data label colours", {
                   data.label.font.color = c("#FF0000", "#00AA00"),
                   average.series = rep(3, 5))
     cols <- decodeJson(x$labelsFontColor)
+    # The length is what tells the two sizings apart. Sized to the charted series alone this
+    # would be 10 rather than 15, and the values below would be identical either way: the
+    # average series labels nothing, and the widget recycles a short array, so the wrong
+    # sizing draws the same chart.
+    expect_length(cols, 15)
     expect_equal(cols[1:5], rep("#FF0000", 5))
     expect_equal(cols[6:10], rep("#00AA00", 5))
 })

--- a/tests/testthat/test-labeledlinechart.R
+++ b/tests/testthat/test-labeledlinechart.R
@@ -66,9 +66,10 @@ test_that("Data label font color falls back to the series color when autocolorin
                   data.label.font.autocolor = TRUE)
     expect_null(x$labelsFontColor)
 
+    # A colour that was set is sent, now as one entry per point rather than one for the chart
     x <- widgetOf(z, data.label.auto.placement = TRUE, data.label.show = TRUE,
                   data.label.font.color = "#123456")
-    expect_equal(x$labelsFontColor, "#123456")
+    expect_equal(decodeJson(x$labelsFontColor), rep("#123456", 10))
 })
 
 test_that("Annotation markup is sent beside the data label, not inside it",
@@ -614,4 +615,40 @@ test_that("Each series keeps its own line shape and smoothing on the labeledLine
                   shape = "Curved", smoothing = 1.3)
     expect_equal(decodeJson(x$lineShape), c("spline", "spline"))
     expect_equal(decodeJson(x$lineSmoothing), c("1.3", "1.3"))
+})
+
+test_that("Each series can colour its data labels", {
+    # The widget takes one colour per point, in the same order as the labels themselves:
+    # every point of the first series, then of the second
+    x <- widgetOf(z, data.label.auto.placement = TRUE, data.label.show = TRUE,
+                  data.label.font.color = c("#FF0000", "#00AA00"))
+    expect_equal(decodeJson(x$labelsFontColor),
+                 c(rep("#FF0000", 5), rep("#00AA00", 5)))
+
+    # A single colour still covers the whole chart
+    x <- widgetOf(z, data.label.auto.placement = TRUE, data.label.show = TRUE,
+                  data.label.font.color = "#123456")
+    expect_equal(decodeJson(x$labelsFontColor), rep("#123456", 10))
+
+    # Automatic colouring still sends nothing, so each label takes its own series' colour
+    x <- widgetOf(z, data.label.auto.placement = TRUE, data.label.show = TRUE,
+                  data.label.font.autocolor = TRUE)
+    expect_null(x$labelsFontColor)
+})
+
+test_that("A per-series data label colour is no longer reported as unsupported", {
+    auto <- function(...) Line(z, data.label.auto.placement = TRUE,
+                               data.label.show = TRUE, ...)
+    expect_warning(auto(data.label.font.color = c("#FF0000", "#00AA00")), NA)
+})
+
+test_that("An average series does not shift the data label colours", {
+    # chart.matrix gains a column for the average, so the per-point colours have to be
+    # sized to that rather than to the charted series alone
+    x <- widgetOf(z, data.label.auto.placement = TRUE, data.label.show = TRUE,
+                  data.label.font.color = c("#FF0000", "#00AA00"),
+                  average.series = rep(3, 5))
+    cols <- decodeJson(x$labelsFontColor)
+    expect_equal(cols[1:5], rep("#FF0000", 5))
+    expect_equal(cols[6:10], rep("#00AA00", 5))
 })

--- a/tests/testthat/test-scatterplot.R
+++ b/tests/testthat/test-scatterplot.R
@@ -119,3 +119,38 @@ test_that("Scatter with trend line that cannot be predicted",
 })
 
 
+test_that("A numeric colour scale keeps a colour for every point", {
+    # With a numeric scale the palette is interpolated into one colour per data point, so
+    # `colors` stops being a per-series palette part way through. Sizing it to the series
+    # count then leaves every point wearing the first point's colour.
+    d <- data.frame(x = 1:10, y = 1:10, col = c(1, 1, 1, 1, 1, 1, 1, 1, 9, 10))
+    attr(d, "scatter.variable.indices") <- c(x = 1, y = 2, sizes = NA, colors = 3)
+    pb <- plotly::plotly_build(suppressWarnings(
+        Scatter(d, scatter.sizes.column = 0, scatter.colors.column = 3,
+                scatter.colors.as.categorical = FALSE,
+                colors = c("blue", "red")))$htmlwidget)
+    marker.traces <- Filter(function(tr) !is.null(tr$marker$color) &&
+                                         length(tr$marker$color) > 1, pb$x$data)
+    expect_length(marker.traces, 1)
+
+    point.colors <- as.character(marker.traces[[1]]$marker$color)
+    expect_length(point.colors, 10)
+    # The two high values sit at the far end of the scale, so they are not the first colour
+    expect_true(point.colors[1] != point.colors[10])
+
+    # The borders default to the point colours and reach the numeric trace whole, rather
+    # than being indexed by series, so they have to stay per point too
+    expect_length(as.character(marker.traces[[1]]$marker$line$color), 10)
+})
+
+test_that("A categorical colour scale still takes one colour per series", {
+    d <- data.frame(x = 1:6, y = 1:6, col = rep(c("a", "b"), each = 3))
+    attr(d, "scatter.variable.indices") <- c(x = 1, y = 2, sizes = NA, colors = 3)
+    pb <- plotly::plotly_build(suppressWarnings(
+        Scatter(d, scatter.sizes.column = 0, scatter.colors.column = 3,
+                scatter.colors.as.categorical = TRUE,
+                colors = c("blue", "red")))$htmlwidget)
+    named <- Filter(function(tr) !is.null(tr$name) && !is.null(tr$marker$color), pb$x$data)
+    cols <- unique(vapply(named, function(tr) as.character(tr$marker$color)[1], character(1)))
+    expect_length(cols, 2)
+})

--- a/tests/testthat/test-scatterplot.R
+++ b/tests/testthat/test-scatterplot.R
@@ -154,3 +154,28 @@ test_that("A categorical colour scale still takes one colour per series", {
     cols <- unique(vapply(named, function(tr) as.character(tr$marker$color)[1], character(1)))
     expect_length(cols, 2)
 })
+
+test_that("A supplied marker border palette covers every point of a numeric scale", {
+    # The border colours default to the point colours, so on a numeric scale they are per
+    # point and must stay that way. A palette the caller supplied is not per point, and
+    # leaving it alone gave a two-colour palette to a ten-point trace, bordering the first
+    # two and leaving the rest with plotly's default. It collapses to the series' value
+    # instead, as the other per-series settings do when there is one series.
+    d <- data.frame(x = 1:10, y = 1:10, col = c(1, 1, 1, 1, 1, 1, 1, 1, 9, 10))
+    attr(d, "scatter.variable.indices") <- c(x = 1, y = 2, sizes = NA, colors = 3)
+    numericTrace <- function(...) {
+        pb <- plotly::plotly_build(suppressWarnings(
+            Scatter(d, scatter.sizes.column = 0, scatter.colors.column = 3,
+                    scatter.colors.as.categorical = FALSE, colors = c("blue", "red"),
+                    ...))$htmlwidget)
+        Filter(function(tr) length(tr$marker$color) > 1, pb$x$data)[[1]]
+    }
+
+    # A palette is not left partially applied
+    borders <- as.character(numericTrace(marker.border.colors = c("black", "red"))$marker$line$color)
+    expect_length(unique(borders), 1)
+    expect_match(borders[1], "rgba(0,0,0", fixed = TRUE)
+
+    # The default still follows the point colours, one each
+    expect_length(as.character(numericTrace()$marker$line$color), 10)
+})


### PR DESCRIPTION
* Enables a data label colour per series on line charts drawn with `data.label.auto.placement`, which the new Plugins controls need. Depends on Displayr/rhtmlCombinedScatter#98. Data label colour per series on line chart (without automatic data label placement) is already supported and documented so no updates to the R docs needed.
* Fixes a diff in a Dimension Reduction Standard R test that directly calls `Scatter`. Out change to vectorize means that it was getting truncated before it built the color scale. Does not affect CombinedScatter.
